### PR TITLE
fix: repair broken imports after dead code removal

### DIFF
--- a/src/components/admin/analytics/AnalyticsDashboard.tsx
+++ b/src/components/admin/analytics/AnalyticsDashboard.tsx
@@ -12,9 +12,9 @@ import { useTelemetryStats, useErrorTrends } from '@/hooks/admin/useTelemetrySta
 import { useGenerationAnalytics } from '@/hooks/useGenerationAnalytics';
 import { TelemetryOverview } from './TelemetryOverview';
 import { ErrorTrendsPanel } from './ErrorTrendsPanel';
-import { GenerationStatsPanel } from './GenerationStatsPanel';
+import { GenerationStatsPanel } from '../GenerationStatsPanel';
 import { PerformanceMetricsPanel } from './PerformanceMetricsPanel';
-import { DeeplinkAnalyticsPanel } from './DeeplinkAnalyticsPanel';
+import { DeeplinkAnalyticsPanel } from '../DeeplinkAnalyticsPanel';
 import { ExperimentsPanel } from './ExperimentsPanel';
 import { RetentionPanel } from './RetentionPanel';
 import { RevenueAnalyticsPanel } from './RevenueAnalyticsPanel';

--- a/src/components/admin/analytics/index.ts
+++ b/src/components/admin/analytics/index.ts
@@ -5,9 +5,7 @@
 export { AnalyticsDashboard } from './AnalyticsDashboard';
 export { TelemetryOverview } from './TelemetryOverview';
 export { ErrorTrendsPanel } from './ErrorTrendsPanel';
-export { GenerationStatsPanel } from './GenerationStatsPanel';
 export { PerformanceMetricsPanel } from './PerformanceMetricsPanel';
-export { DeeplinkAnalyticsPanel } from './DeeplinkAnalyticsPanel';
 export { ExperimentsPanel } from './ExperimentsPanel';
 export { RetentionPanel } from './RetentionPanel';
 export { DeeplinkTrendsChart } from './DeeplinkTrendsChart';

--- a/src/components/generate-form/sections/index.ts
+++ b/src/components/generate-form/sections/index.ts
@@ -1,6 +1,5 @@
 export { TitleSection } from './TitleSection';
 export { StyleSection } from './StyleSection';
 export { VocalsToggle } from './VocalsToggle';
-export { LyricsSection } from './LyricsSection';
 export { LyricsSectionAdvanced } from './LyricsSectionAdvanced';
 export { PrivacyToggle } from './PrivacyToggle';

--- a/src/pages/LyricsStudio.tsx
+++ b/src/pages/LyricsStudio.tsx
@@ -32,14 +32,14 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { 
-  LyricsWorkspace, 
-  LyricsSection, 
-  SectionNotesPanel,
+import {
+  LyricsWorkspace,
+  LyricsSection,
   TagsEditor,
   LyricsHistoryBar,
   LyricsVersionsPanel,
 } from '@/components/lyrics-workspace';
+import { SectionNotesPanel } from '@/components/studio/unified/SectionNotesPanel';
 import { LyricsAIChatAgent } from '@/components/lyrics-workspace/LyricsAIChatAgent';
 import { MobileAIAgentPanel } from '@/components/lyrics-workspace/ai-agent/MobileAIAgentPanel';
 import { useLyricsTemplates } from '@/hooks/useLyricsTemplates';


### PR DESCRIPTION
## Summary
- Fix broken barrel exports in `analytics/index.ts` and `sections/index.ts` referencing deleted files
- Fix `AnalyticsDashboard.tsx` imports to use `../GenerationStatsPanel` and `../DeeplinkAnalyticsPanel`
- Fix `LyricsStudio.tsx` SectionNotesPanel import to use `@/components/studio/unified/SectionNotesPanel`
- Vite production build passes successfully

## Test plan
- [x] `npm run build` passes (46s, 0 errors)
- [x] `tsc --noEmit` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)