### PR TITLE
feat(studio): US3 presets for unified studio (Sprint 031)

### DIFF
--- a/SPRINTS/SPRINT-PROGRESS.md
+++ b/SPRINTS/SPRINT-PROGRESS.md
@@ -6,8 +6,9 @@
 
 | Sprint | Статус | Прогресс |
 |--------|--------|----------|
-| Sprint 001-029 | ✅ ЗАВЕРШЕНЫ | 100% |
-| Sprint 030-032 | ✅ ЗАВЕРШЕНЫ | 100% |
+| Sprint 001-030 | ✅ ЗАВЕРШЕНЫ | 100% |
+| Sprint 031 (Mobile Studio V2) | 🔄 В ПРОЦЕССЕ | US1 ✅ · US3 🟡 · US2/US4–8 частично |
+| Sprint 032 (Professional UI) | ✅ ЗАВЕРШЁН | 100% |
 | Q1 2026 Plan | 🔄 АКТИВЕН | Phase 1-4 Complete, Sprints A-E Complete |
 | Phase 8: Dead Code Removal | ✅ ЗАВЕРШЁН | 196 файлов, 45K строк |
 | Sprint 9A: Deduplication | ✅ ЗАВЕРШЁН | 5 дубликатов, 1.35K строк |

--- a/specs/031-mobile-studio-v2/tasks.md
+++ b/specs/031-mobile-studio-v2/tasks.md
@@ -5,6 +5,14 @@
 
 **Tests**: Tests are OPTIONAL per spec - not explicitly requested. Test tasks omitted to focus on implementation.
 
+> **⚠️ Audit reconciliation (2026-06-25):** `SPRINT-PROGRESS.md` previously claimed Sprint 031 "100% complete" — this is inaccurate. Reality:
+> - **US1 (Lyrics)** ✅ implemented (LyricsPanel, useLyricVersions, SectionNotesPanel wired into StudioShell).
+> - **US2 (MusicLab)** 🟡 partially implemented but under *different* names than tasks below (`MusicLabPanel` uses `useRealtimeChordDetection`/`usePromptDJ`, not the planned `useRecordings`/`useChordDetection`). Checkboxes below were never updated.
+> - **US3 (Presets)** 🟡 hook + PresetManager component now built (this session); dashboard sub-tasks still open.
+> - **US4–US8** mostly exist in scattered/legacy form (`useBatchStemProcessing`, `PianoRoll`, `AIActionsFAB`, `useStudioKeyboardShortcuts`, `SectionReplacementHistory`) but are **not** integrated into the unified StudioShell as specced.
+>
+> Treat the checkboxes as a planning artifact, not ground truth — verify against `src/` before starting any task.
+
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
 ## Format: `[ID] [P?] [Story] Description`
@@ -111,17 +119,17 @@ Single web application structure: `src/`, `supabase/`, `tests/` at repository ro
 
 ### Implementation for User Story 3
 
-- [ ] T040 [P] [US3] Create usePresets hook in src/hooks/usePresets.ts
+- [x] T040 [P] [US3] Create usePresets hook in src/hooks/usePresets.ts (2026-06-25 — wraps presets.api.ts with TanStack Query: list/detail/create/update/delete/apply/clone)
 - [ ] T041 [P] [US3] Create useDashboardStats hook in src/hooks/useDashboardStats.ts
-- [ ] T042 [US3] Create presets service in src/services/presets.service.ts (depends on T040, T041)
+- [~] T042 [US3] Presets service — collapsed into usePresets hook + presets.api.ts per existing project pattern (see useLyricVersions); no separate src/services/presets.service.ts file created
 - [ ] T043 [US3] Create dashboard service in src/services/dashboard.service.ts
-- [ ] T044 [US3] Create ProfessionalDashboard component in src/components/studio/unified/ProfessionalDashboard.tsx
-- [ ] T045 [US3] Create PresetManager component in src/components/studio/unified/PresetManager.tsx
+- [ ] T044 [US3] Create ProfessionalDashboard component in src/components/studio/unified/ProfessionalDashboard.tsx (NOTE: a standalone ProfessionalDashboard already exists at src/pages/ProfessionalDashboard.tsx — needs unified-studio integration, not a new build)
+- [x] T045 [US3] Create PresetManager component in src/components/studio/unified/PresetManager.tsx (2026-06-25 — category tabs, search, apply/save/clone/delete, ownership grouping, 44px targets, haptics)
 - [ ] T046 [US3] Create workflow visualization component in src/components/studio/unified/WorkflowVisualization.tsx
 - [ ] T047 [US3] Create stats cards component in src/components/studio/unified/DashboardStatsCards.tsx
-- [ ] T048 [US3] Integrate ProfessionalDashboard into StudioShell in src/components/studio/unified/StudioShell.tsx
+- [x] T048 [US3] Integrate presets into StudioShell (2026-06-25 — StudioPresetsSheet wraps PresetManager; opened via "Пресеты" action in StudioActionsSheet, applies to project.id). Dashboard/stats integration still pending (T041/T043/T044/T046/T047).
 
-**Checkpoint**: User Story 3 fully functional - users can view stats and manage presets
+**Checkpoint**: Presets sub-story functional — users can browse, apply, save, clone, and delete presets from the studio actions sheet. Dashboard/stats portion of US3 remains open.
 
 ---
 

--- a/src/components/studio/unified/PresetManager.tsx
+++ b/src/components/studio/unified/PresetManager.tsx
@@ -1,0 +1,475 @@
+/**
+ * PresetManager Component (Sprint 031 — US3 Professional Studio Dashboard)
+ *
+ * Mobile-first panel for browsing, applying, creating, and deleting studio
+ * presets. Groups presets by ownership (system / public / mine), supports
+ * search + category filtering, and exposes a "save current settings" flow.
+ *
+ * Features:
+ * - Category tabs (all / vocal / guitar / drums / mastering / fx / custom)
+ * - Search by name or description
+ * - Apply a preset to the active track (with usage tracking)
+ * - Save current studio settings as a new preset
+ * - Clone system/public presets into the user's library
+ * - Delete own presets with confirmation
+ * - Telegram haptic feedback, 44px+ touch targets
+ *
+ * @module src/components/studio/unified/PresetManager
+ * @see src/hooks/usePresets.ts for data management
+ * @see src/api/presets.api.ts for the API layer
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import { motion, AnimatePresence } from '@/lib/motion';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  usePresets,
+  useCreatePreset,
+  useDeletePreset,
+  useApplyPreset,
+  useClonePreset,
+} from '@/hooks/usePresets';
+import { useAuth } from '@/contexts/AuthContext';
+import { useHapticFeedback } from '@/hooks/useHapticFeedback';
+import type {
+  Preset,
+  PresetCategory,
+  PresetSettings,
+} from '@/api/presets.api';
+import { cn } from '@/lib/utils';
+import {
+  Search,
+  Plus,
+  Trash2,
+  Copy,
+  Check,
+  Lock,
+  Globe,
+  User as UserIcon,
+  Sparkles,
+  Loader2,
+} from '@/lib/icons';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CATEGORIES: { value: PresetCategory | 'all'; label: string }[] = [
+  { value: 'all', label: 'Все' },
+  { value: 'vocal', label: 'Вокал' },
+  { value: 'guitar', label: 'Гитара' },
+  { value: 'drums', label: 'Ударные' },
+  { value: 'mastering', label: 'Мастеринг' },
+  { value: 'fx', label: 'Эффекты' },
+  { value: 'custom', label: 'Свои' },
+];
+
+interface PresetManagerProps {
+  /** Track the preset will be applied to. When absent, apply is disabled. */
+  trackId?: string;
+  /** Current studio settings to capture when saving a new preset. */
+  currentSettings?: PresetSettings;
+  /** Default category used when saving a new preset. */
+  defaultCategory?: PresetCategory;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ownershipBadge(preset: Preset) {
+  if (preset.is_system) {
+    return { icon: Lock, label: 'Системный', tone: 'text-amber-400' };
+  }
+  if (preset.is_public) {
+    return { icon: Globe, label: 'Публичный', tone: 'text-sky-400' };
+  }
+  return { icon: UserIcon, label: 'Мой', tone: 'text-emerald-400' };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PresetManager({
+  trackId,
+  currentSettings,
+  defaultCategory = 'custom',
+  className,
+}: PresetManagerProps) {
+  const { user } = useAuth();
+  const haptic = useHapticFeedback();
+
+  const [category, setCategory] = useState<PresetCategory | 'all'>('all');
+  const [search, setSearch] = useState('');
+  const [appliedId, setAppliedId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<Preset | null>(null);
+  const [saveOpen, setSaveOpen] = useState(false);
+
+  const { presets, isLoading } = usePresets({
+    category: category === 'all' ? undefined : category,
+    userId: user?.id,
+    searchQuery: search.trim() || undefined,
+  });
+
+  const { applyPreset, isApplying } = useApplyPreset();
+  const { deletePreset, isDeleting } = useDeletePreset();
+  const { clonePreset, isCloning } = useClonePreset();
+
+  // Group presets by ownership for clearer scanning on mobile
+  const grouped = useMemo(() => {
+    const mine: Preset[] = [];
+    const system: Preset[] = [];
+    const community: Preset[] = [];
+    for (const p of presets) {
+      if (p.is_system) system.push(p);
+      else if (p.user_id === user?.id) mine.push(p);
+      else community.push(p);
+    }
+    return { mine, system, community };
+  }, [presets, user?.id]);
+
+  const handleApply = useCallback(
+    (preset: Preset) => {
+      if (!trackId) return;
+      haptic.tap();
+      applyPreset(
+        { trackId, presetId: preset.id },
+        { onSuccess: () => setAppliedId(preset.id) }
+      );
+    },
+    [trackId, applyPreset, haptic]
+  );
+
+  const handleDelete = useCallback(() => {
+    if (!pendingDelete) return;
+    haptic.warning();
+    deletePreset(pendingDelete.id, { onSettled: () => setPendingDelete(null) });
+  }, [pendingDelete, deletePreset, haptic]);
+
+  const handleClone = useCallback(
+    (preset: Preset) => {
+      haptic.tap();
+      clonePreset({ presetId: preset.id });
+    },
+    [clonePreset, haptic]
+  );
+
+  const renderPreset = (preset: Preset) => {
+    const badge = ownershipBadge(preset);
+    const BadgeIcon = badge.icon;
+    const isOwn = !preset.is_system && preset.user_id === user?.id;
+    const isApplied = appliedId === preset.id;
+
+    return (
+      <motion.div
+        key={preset.id}
+        layout
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -8 }}
+      >
+        <Card className="border-border/60 bg-card/60">
+          <CardContent className="flex items-center gap-3 p-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium">{preset.name}</span>
+                <BadgeIcon className={cn('h-3.5 w-3.5 shrink-0', badge.tone)} />
+              </div>
+              {preset.description && (
+                <p className="truncate text-xs text-muted-foreground">
+                  {preset.description}
+                </p>
+              )}
+              <div className="mt-1 flex items-center gap-2">
+                <Badge variant="secondary" className="text-[10px] uppercase">
+                  {preset.category}
+                </Badge>
+                {preset.usage_count > 0 && (
+                  <span className="text-[10px] text-muted-foreground">
+                    {preset.usage_count} использований
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="flex shrink-0 items-center gap-1">
+              {trackId && (
+                <Button
+                  size="sm"
+                  variant={isApplied ? 'secondary' : 'default'}
+                  className="h-11 min-w-[44px] px-3"
+                  disabled={isApplying}
+                  onClick={() => handleApply(preset)}
+                >
+                  {isApplied ? <Check className="h-4 w-4" /> : 'Применить'}
+                </Button>
+              )}
+              {!isOwn && user?.id && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-11 w-11"
+                  disabled={isCloning}
+                  onClick={() => handleClone(preset)}
+                  aria-label="Скопировать пресет"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              )}
+              {isOwn && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-11 w-11 text-destructive"
+                  onClick={() => setPendingDelete(preset)}
+                  aria-label="Удалить пресет"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+    );
+  };
+
+  const renderGroup = (title: string, items: Preset[]) => {
+    if (items.length === 0) return null;
+    return (
+      <div className="space-y-2">
+        <h4 className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h4>
+        <AnimatePresence initial={false}>{items.map(renderPreset)}</AnimatePresence>
+      </div>
+    );
+  };
+
+  const isEmpty =
+    !isLoading &&
+    grouped.mine.length === 0 &&
+    grouped.system.length === 0 &&
+    grouped.community.length === 0;
+
+  return (
+    <div className={cn('flex h-full flex-col gap-3', className)}>
+      {/* Search + Save */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Поиск пресетов…"
+            className="h-11 pl-9"
+          />
+        </div>
+        {currentSettings && user?.id && (
+          <Button
+            size="sm"
+            className="h-11 gap-1.5 px-3"
+            onClick={() => {
+              haptic.tap();
+              setSaveOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            Сохранить
+          </Button>
+        )}
+      </div>
+
+      {/* Category tabs */}
+      <Tabs value={category} onValueChange={(v) => setCategory(v as PresetCategory | 'all')}>
+        <ScrollArea className="w-full">
+          <TabsList className="inline-flex w-max">
+            {CATEGORIES.map((c) => (
+              <TabsTrigger key={c.value} value={c.value} className="text-xs">
+                {c.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </ScrollArea>
+      </Tabs>
+
+      {/* List */}
+      <ScrollArea className="flex-1">
+        <div className="space-y-4 pb-4 pr-2">
+          {isLoading && (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </div>
+          )}
+
+          {isEmpty && (
+            <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-muted-foreground">
+              <Sparkles className="h-8 w-8 opacity-50" />
+              <p className="text-sm">Пресеты не найдены</p>
+              {currentSettings && user?.id && (
+                <Button variant="link" size="sm" onClick={() => setSaveOpen(true)}>
+                  Сохранить текущие настройки
+                </Button>
+              )}
+            </div>
+          )}
+
+          {renderGroup('Мои пресеты', grouped.mine)}
+          {renderGroup('Системные', grouped.system)}
+          {renderGroup('Сообщество', grouped.community)}
+        </div>
+      </ScrollArea>
+
+      {/* Save dialog */}
+      <SavePresetDialog
+        open={saveOpen}
+        onOpenChange={setSaveOpen}
+        settings={currentSettings}
+        defaultCategory={defaultCategory}
+      />
+
+      {/* Delete confirmation */}
+      <Dialog open={!!pendingDelete} onOpenChange={(o) => !o && setPendingDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Удалить пресет?</DialogTitle>
+            <DialogDescription>
+              «{pendingDelete?.name}» будет удалён без возможности восстановления.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setPendingDelete(null)}>
+              Отмена
+            </Button>
+            <Button variant="destructive" disabled={isDeleting} onClick={handleDelete}>
+              {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Удалить'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Save dialog (internal)
+// ---------------------------------------------------------------------------
+
+interface SavePresetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  settings?: PresetSettings;
+  defaultCategory: PresetCategory;
+}
+
+function SavePresetDialog({
+  open,
+  onOpenChange,
+  settings,
+  defaultCategory,
+}: SavePresetDialogProps) {
+  const haptic = useHapticFeedback();
+  const { createPreset, isCreating } = useCreatePreset();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<PresetCategory>(defaultCategory);
+
+  const reset = () => {
+    setName('');
+    setDescription('');
+    setCategory(defaultCategory);
+  };
+
+  const handleSave = () => {
+    if (!name.trim() || !settings) return;
+    haptic.success();
+    createPreset(
+      {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        category,
+        settings,
+      },
+      {
+        onSuccess: () => {
+          reset();
+          onOpenChange(false);
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Сохранить пресет</DialogTitle>
+          <DialogDescription>
+            Текущие настройки студии будут сохранены как пресет.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Название пресета"
+            className="h-11"
+            maxLength={100}
+            autoFocus
+          />
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Описание (необязательно)"
+            rows={2}
+          />
+          <Tabs value={category} onValueChange={(v) => setCategory(v as PresetCategory)}>
+            <ScrollArea className="w-full">
+              <TabsList className="inline-flex w-max">
+                {CATEGORIES.filter((c) => c.value !== 'all').map((c) => (
+                  <TabsTrigger key={c.value} value={c.value} className="text-xs">
+                    {c.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </ScrollArea>
+          </Tabs>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Отмена
+          </Button>
+          <Button disabled={!name.trim() || isCreating} onClick={handleSave}>
+            {isCreating ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Сохранить'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default PresetManager;

--- a/src/components/studio/unified/StudioActionsSheet.tsx
+++ b/src/components/studio/unified/StudioActionsSheet.tsx
@@ -25,6 +25,7 @@ import {
   FileText,
   FlaskConical,
   Layers,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { useHapticFeedback } from '@/hooks/useHapticFeedback';
 import { glass } from '@/lib/glass';
@@ -46,6 +47,8 @@ interface StudioActionsSheetProps {
   onOpenMusicLab?: () => void;
   /** Open Lyrics editor (unified interface) */
   onOpenLyrics?: () => void;
+  /** Open Presets library (apply/save mixer & effects presets) */
+  onOpenPresets?: () => void;
   /** Open Batch Processing panel */
   onOpenBatchProcessing?: () => void;
 }
@@ -120,6 +123,7 @@ export const StudioActionsSheet = memo(function StudioActionsSheet({
   onBack,
   onOpenMusicLab,
   onOpenLyrics,
+  onOpenPresets,
   onOpenBatchProcessing,
 }: StudioActionsSheetProps) {
   const handleAction = (action: () => void) => {
@@ -136,7 +140,7 @@ export const StudioActionsSheet = memo(function StudioActionsSheet({
 
         <div className="space-y-1">
           {/* Creative tools - MusicLab and Lyrics (unified interface) */}
-          {(onOpenMusicLab || onOpenLyrics) && (
+          {(onOpenMusicLab || onOpenLyrics || onOpenPresets) && (
             <div className="space-y-1 pb-3 border-b border-border/50">
               {onOpenMusicLab && (
                 <ActionItem
@@ -153,6 +157,14 @@ export const StudioActionsSheet = memo(function StudioActionsSheet({
                   label="Редактор текста"
                   description="AI помощник, версии"
                   onClick={() => handleAction(onOpenLyrics)}
+                />
+              )}
+              {onOpenPresets && (
+                <ActionItem
+                  icon={<SlidersHorizontal className="w-5 h-5" />}
+                  label="Пресеты"
+                  description="Применить или сохранить настройки"
+                  onClick={() => handleAction(onOpenPresets)}
                 />
               )}
             </div>

--- a/src/components/studio/unified/StudioPresetsSheet.tsx
+++ b/src/components/studio/unified/StudioPresetsSheet.tsx
@@ -1,0 +1,71 @@
+/**
+ * StudioPresetsSheet — bottom sheet wrapper around PresetManager (Sprint 031 US3)
+ *
+ * Surfaces the preset library inside the unified studio so users can apply
+ * saved mixer/effects presets to the active track or save the current studio
+ * settings as a new preset.
+ *
+ * @module src/components/studio/unified/StudioPresetsSheet
+ * @see src/components/studio/unified/PresetManager.tsx
+ */
+
+import { memo } from 'react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { PresetManager } from './PresetManager';
+import type { PresetCategory, PresetSettings } from '@/api/presets.api';
+import { SlidersHorizontal, X } from '@/lib/icons';
+
+interface StudioPresetsSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Active track the preset is applied to. */
+  trackId?: string;
+  /** Current studio settings captured when saving a new preset. */
+  currentSettings?: PresetSettings;
+  /** Default category for the save dialog. */
+  defaultCategory?: PresetCategory;
+}
+
+export const StudioPresetsSheet = memo(function StudioPresetsSheet({
+  open,
+  onOpenChange,
+  trackId,
+  currentSettings,
+  defaultCategory = 'mastering',
+}: StudioPresetsSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="flex h-[85vh] flex-col rounded-t-2xl p-0">
+        <SheetHeader className="border-b p-4 pb-3">
+          <div className="flex items-center justify-between">
+            <SheetTitle className="flex items-center gap-2">
+              <SlidersHorizontal className="h-5 w-5 text-primary" />
+              Пресеты
+            </SheetTitle>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9"
+              onClick={() => onOpenChange(false)}
+              aria-label="Закрыть"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 p-4">
+          <PresetManager
+            trackId={trackId}
+            currentSettings={currentSettings}
+            defaultCategory={defaultCategory}
+            className="h-full"
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+});
+
+export default StudioPresetsSheet;

--- a/src/components/studio/unified/StudioShell.tsx
+++ b/src/components/studio/unified/StudioShell.tsx
@@ -49,6 +49,7 @@ import { AutoSaveIndicator } from './AutoSaveIndicator';
 import { LyricsPanel } from './LyricsPanel';
 import { StudioLyricsSheet } from './StudioLyricsSheet';
 import { StudioMusicLabSheet } from './StudioMusicLabSheet';
+import { StudioPresetsSheet } from './StudioPresetsSheet';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -223,6 +224,9 @@ export const StudioShell = memo(function StudioShell({ className }: StudioShellP
   
   // Lyrics sheet state (opens as overlay, not tab)
   const [showLyricsSheet, setShowLyricsSheet] = useState(false);
+
+  // Presets sheet state (Sprint 031 US3 - opens as overlay)
+  const [showPresetsSheet, setShowPresetsSheet] = useState(false);
 
   // Section editor store
   const {
@@ -1360,6 +1364,16 @@ export const StudioShell = memo(function StudioShell({ className }: StudioShellP
         onBack={handleBack}
         onOpenMusicLab={() => setShowMusicLabSheet(true)}
         onOpenLyrics={() => setShowLyricsSheet(true)}
+        onOpenPresets={() => setShowPresetsSheet(true)}
+      />
+
+      {/* Presets Sheet - apply/save mixer & effects presets (Sprint 031 US3) */}
+      <StudioPresetsSheet
+        open={showPresetsSheet}
+        onOpenChange={setShowPresetsSheet}
+        trackId={project.id}
+        currentSettings={{ mixer: { volume: project.masterVolume, pan: 0 } }}
+        defaultCategory="mastering"
       />
 
       {/* Mobile Mixer Sheet */}

--- a/src/components/studio/unified/index.ts
+++ b/src/components/studio/unified/index.ts
@@ -43,6 +43,8 @@ export { RecordTrackDrawer } from './RecordTrackDrawer';
 export type { RecordingType } from './RecordTrackDrawer';
 export { MusicLabPanel } from './MusicLabPanel';
 export { StudioMusicLabSheet } from './StudioMusicLabSheet';
+export { PresetManager } from './PresetManager';
+export { StudioPresetsSheet } from './StudioPresetsSheet';
 export { NotationDrawer } from './NotationDrawer';
 export type { NotationDrawerProps } from './NotationDrawer';
 export { ChordOverlay } from './ChordOverlay';

--- a/src/hooks/usePresets.ts
+++ b/src/hooks/usePresets.ts
@@ -1,0 +1,293 @@
+/**
+ * Presets Hook (Sprint 031 — US3 Professional Studio Dashboard)
+ *
+ * TanStack Query hook for managing studio presets (vocal, guitar, drums,
+ * mastering, stem separation, MIDI). Wraps the presets API layer with caching,
+ * optimistic updates, and toast notifications.
+ *
+ * @example
+ * const { presets, isLoading } = usePresets({ category: 'vocal' });
+ * const { createPreset, isCreating } = useCreatePreset();
+ * const { applyPreset } = useApplyPreset();
+ *
+ * @module src/hooks/usePresets
+ * @see src/api/presets.api.ts for the API layer
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  getPresets,
+  getPresetById,
+  createPreset,
+  updatePreset,
+  deletePreset,
+  applyPresetToTrack,
+  clonePreset,
+  type Preset,
+  type PresetFilters,
+  type CreatePresetInput,
+  type UpdatePresetInput,
+} from '@/api/presets.api';
+import { toast } from 'sonner';
+import { logger } from '@/lib/logger';
+
+// ============================================================================
+// Query Keys Factory
+// ============================================================================
+
+export const presetsKeys = {
+  all: ['presets'] as const,
+  list: (filters?: PresetFilters) => ['presets', 'list', filters || {}] as const,
+  detail: (presetId: string) => ['presets', 'detail', presetId] as const,
+} as const;
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch presets, optionally filtered by category, scope, owner, or search.
+ *
+ * @param filters - Optional filters for category, scope, userId, and search
+ * @returns Query result with `presets` array and loading/error state
+ */
+export function usePresets(filters?: PresetFilters) {
+  const query = useQuery({
+    queryKey: presetsKeys.list(filters),
+    queryFn: async () => {
+      const { presets, error } = await getPresets(filters);
+      if (error) throw error;
+      return presets;
+    },
+    staleTime: 5 * 60 * 1000, // presets change rarely
+    gcTime: 10 * 60 * 1000,
+  });
+
+  return {
+    presets: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+/**
+ * Fetch a single preset by ID.
+ */
+export function usePreset(presetId: string | undefined) {
+  return useQuery({
+    queryKey: presetsKeys.detail(presetId || ''),
+    queryFn: async () => {
+      if (!presetId) throw new Error('Preset ID is required');
+      const { data, error } = await getPresetById(presetId);
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!presetId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Create a new user preset.
+ */
+export function useCreatePreset() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  const mutation = useMutation({
+    mutationFn: async (input: CreatePresetInput) => {
+      if (!user?.id) {
+        throw new Error('You must be signed in to save presets');
+      }
+      const { preset, error } = await createPreset(input, user.id);
+      if (error || !preset) throw error ?? new Error('Failed to create preset');
+      return preset;
+    },
+    onSuccess: (preset) => {
+      logger.info('Preset created', { presetId: preset.id, category: preset.category });
+      toast.success('Пресет сохранён', { description: preset.name });
+      queryClient.invalidateQueries({ queryKey: presetsKeys.all });
+    },
+    onError: (error) => {
+      logger.error('Failed to create preset', { error });
+      toast.error('Не удалось сохранить пресет', {
+        description: error instanceof Error ? error.message : 'Неизвестная ошибка',
+      });
+    },
+  });
+
+  return {
+    createPreset: mutation.mutate,
+    createPresetAsync: mutation.mutateAsync,
+    isCreating: mutation.isPending,
+    error: mutation.error,
+  };
+}
+
+/**
+ * Update an existing user preset.
+ */
+export function useUpdatePreset() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  const mutation = useMutation({
+    mutationFn: async ({ presetId, input }: { presetId: string; input: UpdatePresetInput }) => {
+      if (!user?.id) {
+        throw new Error('You must be signed in to edit presets');
+      }
+      const { preset, error } = await updatePreset(presetId, input, user.id);
+      if (error || !preset) throw error ?? new Error('Failed to update preset');
+      return preset;
+    },
+    onSuccess: (preset) => {
+      logger.info('Preset updated', { presetId: preset.id });
+      toast.success('Пресет обновлён', { description: preset.name });
+      queryClient.invalidateQueries({ queryKey: presetsKeys.all });
+    },
+    onError: (error) => {
+      logger.error('Failed to update preset', { error });
+      toast.error('Не удалось обновить пресет', {
+        description: error instanceof Error ? error.message : 'Неизвестная ошибка',
+      });
+    },
+  });
+
+  return {
+    updatePreset: mutation.mutate,
+    updatePresetAsync: mutation.mutateAsync,
+    isUpdating: mutation.isPending,
+    error: mutation.error,
+  };
+}
+
+/**
+ * Delete a user preset (with optimistic removal from cached lists).
+ */
+export function useDeletePreset() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  const mutation = useMutation({
+    mutationFn: async (presetId: string) => {
+      if (!user?.id) {
+        throw new Error('You must be signed in to delete presets');
+      }
+      const { success, error } = await deletePreset(presetId, user.id);
+      if (error || !success) throw error ?? new Error('Failed to delete preset');
+      return presetId;
+    },
+    onMutate: async (presetId) => {
+      await queryClient.cancelQueries({ queryKey: presetsKeys.all });
+      const snapshots = queryClient.getQueriesData<Preset[]>({ queryKey: ['presets', 'list'] });
+      snapshots.forEach(([key, data]) => {
+        if (data) {
+          queryClient.setQueryData(
+            key,
+            data.filter((p) => p.id !== presetId)
+          );
+        }
+      });
+      return { snapshots };
+    },
+    onError: (error, _presetId, context) => {
+      context?.snapshots?.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+      logger.error('Failed to delete preset', { error });
+      toast.error('Не удалось удалить пресет', {
+        description: error instanceof Error ? error.message : 'Неизвестная ошибка',
+      });
+    },
+    onSuccess: () => {
+      toast.success('Пресет удалён');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: presetsKeys.all });
+    },
+  });
+
+  return {
+    deletePreset: mutation.mutate,
+    deletePresetAsync: mutation.mutateAsync,
+    isDeleting: mutation.isPending,
+    error: mutation.error,
+  };
+}
+
+/**
+ * Apply a preset's settings to a track.
+ */
+export function useApplyPreset() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ trackId, presetId }: { trackId: string; presetId: string }) => {
+      const { success, appliedSettings, error } = await applyPresetToTrack(trackId, presetId);
+      if (error || !success) throw error ?? new Error('Failed to apply preset');
+      return appliedSettings;
+    },
+    onSuccess: () => {
+      toast.success('Пресет применён');
+      // usage_count changed on the server — refresh lists so sorting reflects it
+      queryClient.invalidateQueries({ queryKey: presetsKeys.all });
+    },
+    onError: (error) => {
+      logger.error('Failed to apply preset', { error });
+      toast.error('Не удалось применить пресет', {
+        description: error instanceof Error ? error.message : 'Неизвестная ошибка',
+      });
+    },
+  });
+
+  return {
+    applyPreset: mutation.mutate,
+    applyPresetAsync: mutation.mutateAsync,
+    appliedSettings: mutation.data,
+    isApplying: mutation.isPending,
+    error: mutation.error,
+  };
+}
+
+/**
+ * Clone a public/system preset into the current user's library for editing.
+ */
+export function useClonePreset() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  const mutation = useMutation({
+    mutationFn: async ({ presetId, newName }: { presetId: string; newName?: string }) => {
+      if (!user?.id) {
+        throw new Error('You must be signed in to clone presets');
+      }
+      const { preset, error } = await clonePreset(presetId, user.id, newName);
+      if (error || !preset) throw error ?? new Error('Failed to clone preset');
+      return preset;
+    },
+    onSuccess: (preset) => {
+      toast.success('Копия пресета создана', { description: preset.name });
+      queryClient.invalidateQueries({ queryKey: presetsKeys.all });
+    },
+    onError: (error) => {
+      logger.error('Failed to clone preset', { error });
+      toast.error('Не удалось скопировать пресет', {
+        description: error instanceof Error ? error.message : 'Неизвестная ошибка',
+      });
+    },
+  });
+
+  return {
+    clonePreset: mutation.mutate,
+    clonePresetAsync: mutation.mutateAsync,
+    isCloning: mutation.isPending,
+    error: mutation.error,
+  };
+}


### PR DESCRIPTION
## 📝 Описание

Реализует недостающий вертикальный срез **US3 — Presets** для спринта 031 (Mobile Studio V2). Миграция БД (`presets` table) и `presets.api.ts` уже существовали, но хук, UI и интеграция в студию отсутствовали (0 файлов). PR закрывает этот пробел и подключает пресеты к unified studio.

**Что добавлено:**
- `usePresets` hook — TanStack Query поверх `presets.api.ts` (list/detail + create/update/delete/apply/clone, оптимистичное удаление, тосты, логирование) по паттерну `useLyricVersions`.
- `PresetManager` — мобильный компонент: вкладки категорий, поиск, группировка по владению (мои/системные/сообщество), применение к треку, диалог «Сохранить текущие настройки», клон, удаление с подтверждением. 44px+ таргеты, haptics, иконки из `@/lib/icons`.
- `StudioPresetsSheet` — bottom-sheet обёртка по образцу `StudioMusicLabSheet`.
- Интеграция в `StudioShell`: новый пункт «Пресеты» в `StudioActionsSheet` (`onOpenPresets`), применяется к `project.id` (активный трек).

**Аудит:** `SPRINT-PROGRESS.md` заявлял спринт 031 как «100% завершён», что неверно. Исправлен трекер и добавлена заметка реконсиляции в `tasks.md` (чекбоксы разошлись с кодом; US2–US8 существуют частично под другими именами и не интегрированы).

## 🎯 Тип изменения

- [x] ✨ New feature (новая функция)
- [x] 📚 Documentation (обновление трекеров спринта)

## 🔗 Связанные Issues

Related to Sprint 031 (Mobile Studio V2), spec `specs/031-mobile-studio-v2/`

## 📋 Чеклист

### 🔍 Код
- [x] Код следует стайл-гайду проекта (паттерн hook→api, иконки через `@/lib/icons`, без `@ts-nocheck`)
- [x] Самопроверка проведена
- [x] JSDoc добавлен к новым модулям
- [x] Новых предупреждений не генерируется

### 🔨 Сборка
- [x] `tsc --noEmit` — 0 ошибок
- [x] `eslint` (новые/изменённые файлы) — 0 ошибок
- [ ] `npm run test` — не затрагивалось (тесты для US3 не специфицированы)

### 🔐 Безопасность
- [x] Секреты/ключи не коммитятся; запись пресетов защищена существующими RLS-политиками таблицы `presets`

## 🧪 Тестирование

Ручная проверка потока: mobile player bar → «Действия» → «Пресеты» → лист с применением/сохранением/клоном/удалением. Применение идёт через RPC `apply_preset_to_track`.

> ⚠️ Не покрыто: десктопный `AIActionsFAB` пока не показывает пресеты (целевой путь спринта — мобильный `StudioActionsSheet`). Паритет можно добавить отдельно.

## 🎨 UI/UX изменения

- **Компоненты затронуты:** `StudioActionsSheet` (новый пункт «Пресеты»), `StudioShell` (рендер листа)
- **Новые паттерны:** `StudioPresetsSheet` следует существующему паттерну `StudioMusicLabSheet`

## 🔄 Миграция

Требуется ли миграция?
- [x] Нет (`20260106_presets.sql` уже в репозитории)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
