### PR TITLE
feat: migrate design system to warm dark theme and add home page sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       name="keywords"
       content="AI music, генерация музыки, музыкальный редактор, искусственный интеллект, Telegram"
     />
-    <meta name="theme-color" content="hsl(220, 20%, 7%)" id="theme-color-meta" />
+    <meta name="theme-color" content="#140f0c" id="theme-color-meta" />
     <link rel="canonical" href="https://aimusicverse.lovable.app/" />
     <link
       rel="icon"
@@ -72,15 +72,15 @@
     <link rel="dns-prefetch" href="https://apibox.erweima.ai" />
     <link rel="preconnect" href="https://apibox.erweima.ai" crossorigin />
 
-    <!-- Critical fonts with display:swap for faster loading -->
+    <!-- Critical fonts: Onest (UI) + Unbounded (display) + JetBrains Mono (code) -->
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Onest:wght@400;500;600;700&family=Unbounded:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
       media="print"
       onload="this.media = 'all'"
     />
     <noscript
-      ><link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"
+      ><link href="https://fonts.googleapis.com/css2?family=Onest:wght@400;500;600;700&family=Unbounded:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"
     /></noscript>
 
     <!-- Preload critical assets -->

--- a/src/components/generation/GenerationProgressStage.tsx
+++ b/src/components/generation/GenerationProgressStage.tsx
@@ -12,22 +12,22 @@ interface GenerationProgressStageProps {
 }
 
 const stages = [
-  { id: "pending", label: "Очередь", icon: Sparkles, progress: 10 },
-  { id: "analyzing", label: "Анализ промпта", icon: Wand2, progress: 25 },
-  { id: "processing", label: "Генерация музыки", icon: Music2, progress: 50 },
-  { id: "streaming_ready", label: "▶️ Можно слушать!", icon: Music2, progress: 80 },
-  { id: "completed", label: "Готово!", icon: CheckCircle2, progress: 100 },
+  { id: "pending", label: "Анализирую запрос", subtitle: "Понимаю настроение и референсы", icon: Sparkles, progress: 10 },
+  { id: "analyzing", label: "Подбираю стиль и темп", subtitle: "Стиль · BPM · тональность", icon: Wand2, progress: 25 },
+  { id: "processing", label: "Генерирую вокал", subtitle: "Синтез голоса и мелодии", icon: Music2, progress: 50 },
+  { id: "streaming_ready", label: "Свожу трек", subtitle: "Микс, мастеринг, обложка", icon: Music2, progress: 80 },
+  { id: "completed", label: "Готово!", subtitle: "Трек готов к прослушиванию", icon: CheckCircle2, progress: 100 },
 ];
 
 function getStageInfo(status: string) {
-  const stageMap: Record<string, { label: string; progress: number; icon: React.ElementType }> = {
-    pending: { label: "В очереди", progress: 10, icon: Sparkles },
-    processing: { label: "Генерация музыки", progress: 50, icon: Music2 },
-    streaming_ready: { label: "Превью готово", progress: 80, icon: Music2 },
-    completed: { label: "Готово!", progress: 100, icon: CheckCircle2 },
-    failed: { label: "Ошибка", progress: 0, icon: AlertCircle },
+  const stageMap: Record<string, { label: string; subtitle: string; progress: number; icon: React.ElementType }> = {
+    pending: { label: "Анализирую запрос", subtitle: "Понимаю настроение и референсы", progress: 10, icon: Sparkles },
+    processing: { label: "Генерирую вокал", subtitle: "Синтез голоса и мелодии", progress: 50, icon: Music2 },
+    streaming_ready: { label: "Свожу трек", subtitle: "Микс, мастеринг, обложка", progress: 80, icon: Music2 },
+    completed: { label: "Готово!", subtitle: "Трек готов к прослушиванию", progress: 100, icon: CheckCircle2 },
+    failed: { label: "Ошибка", subtitle: "Попробуйте снова", progress: 0, icon: AlertCircle },
   };
-  return stageMap[status] || { label: "Обработка", progress: 30, icon: Loader2 };
+  return stageMap[status] || { label: "Обработка", subtitle: "Подождите…", progress: 30, icon: Loader2 };
 }
 
 function formatTime(seconds: number): string {
@@ -99,7 +99,9 @@ export function GenerationProgressStage({ status, prompt, estimatedTime, classNa
             </Badge>
           </div>
 
-          {prompt && <p className="text-sm text-muted-foreground truncate max-w-[200px]">{prompt}</p>}
+          {stageInfo.subtitle && (
+            <p className="text-sm text-muted-foreground">{stageInfo.subtitle}</p>
+          )}
 
           {estimatedTime && estimatedTime > 0 && !isCompleted && (
             <p className="text-xs text-muted-foreground mt-1">Осталось: {formatTime(estimatedTime)}</p>
@@ -113,9 +115,9 @@ export function GenerationProgressStage({ status, prompt, estimatedTime, classNa
 
         {/* Stage markers */}
         <div className="flex justify-between text-xs text-muted-foreground">
-          <span className={stageInfo.progress >= 10 ? "text-primary" : ""}>Начало</span>
+          <span className={stageInfo.progress >= 10 ? "text-primary" : ""}>Анализ</span>
           <span className={stageInfo.progress >= 50 ? "text-primary" : ""}>Генерация</span>
-          <span className={stageInfo.progress >= 80 ? "text-primary" : ""}>Обработка</span>
+          <span className={stageInfo.progress >= 80 ? "text-primary" : ""}>Сведение</span>
           <span className={stageInfo.progress >= 100 ? "text-green-500" : ""}>Готово</span>
         </div>
       </div>

--- a/src/components/home/AiSuggestions.tsx
+++ b/src/components/home/AiSuggestions.tsx
@@ -1,0 +1,52 @@
+import { Sparkles } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+interface Suggestion {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+interface AiSuggestionsProps {
+  onCreateClick: () => void;
+  className?: string;
+}
+
+const defaultSuggestions: Suggestion[] = [
+  {
+    icon: "🌙",
+    title: "Продолжи последний трек",
+    description: "Добавь второй куплет и более плотный бас — в стиле твоего черновика.",
+  },
+  {
+    icon: "🎙️",
+    title: "Создай AI-артиста из голоса",
+    description: "У тебя есть треки в одном тембре — собери их в единый профиль.",
+  },
+];
+
+export function AiSuggestions({ onCreateClick, className }: AiSuggestionsProps) {
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex items-center gap-2">
+        <Sparkles className="w-4 h-4 text-primary" />
+        <h3 className="font-sans font-bold text-[17px] text-foreground">AI предлагает</h3>
+      </div>
+      <div className="flex flex-col gap-3">
+        {defaultSuggestions.map((sg) => (
+          <button
+            key={sg.title}
+            onClick={onCreateClick}
+            className="p-4 rounded-2xl bg-gradient-to-br from-card to-card/80 border border-border hover:border-primary/30 transition-colors text-left"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-lg">{sg.icon}</span>
+              <p className="font-semibold text-[14.5px] text-foreground/90">{sg.title}</p>
+            </div>
+            <p className="text-[13px] text-muted-foreground mt-2 leading-relaxed">{sg.description}</p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/CommunityTrending.tsx
+++ b/src/components/home/CommunityTrending.tsx
@@ -1,0 +1,53 @@
+import { Play } from "@/lib/icons";
+import { Track } from "@/types/track";
+import { LazyImage } from "@/components/ui/lazy-image";
+import { cn } from "@/lib/utils";
+
+interface CommunityTrendingProps {
+  tracks: Track[];
+  onTrackClick: (track: Track) => void;
+  className?: string;
+}
+
+function formatPlayCount(count: number): string {
+  if (count >= 1000) return `${(count / 1000).toFixed(1)}K`;
+  return String(count);
+}
+
+export function CommunityTrending({ tracks, onTrackClick, className }: CommunityTrendingProps) {
+  if (!tracks || tracks.length === 0) return null;
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <h3 className="font-sans font-bold text-[17px] text-foreground">В тренде сообщества</h3>
+      <div className="flex flex-col gap-1">
+        {tracks.slice(0, 4).map((track) => (
+          <button
+            key={track.id}
+            onClick={() => onTrackClick(track)}
+            className="flex items-center gap-3.5 p-2.5 rounded-[14px] hover:bg-card/60 transition-colors text-left w-full"
+          >
+            <div className="relative w-[50px] h-[50px] rounded-xl overflow-hidden flex-shrink-0">
+              <LazyImage
+                src={track.cover_url || ""}
+                alt={track.title}
+                className="w-full h-full object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-radial from-white/25 to-transparent opacity-60" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-semibold text-[14.5px] text-foreground/90 truncate">{track.title}</p>
+              <p className="text-[12.5px] text-muted-foreground mt-0.5 truncate">
+                AI · {track.style || ""}
+              </p>
+            </div>
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Play className="w-3.5 h-3.5 fill-primary text-primary" />
+              <span>{formatPlayCount(track.play_count || 0)}</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/player/MobileFullscreenPlayer.tsx
+++ b/src/components/player/MobileFullscreenPlayer.tsx
@@ -12,7 +12,7 @@
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { X, ListMusic, BarChart3, ChevronLeft, ChevronRight, Mic2 } from "@/lib/icons";
+import { X, ListMusic, BarChart3, ChevronLeft, ChevronRight, Mic2, Sparkles } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 import { WaveformProgressBar } from "./WaveformProgressBar";
 import { Track } from "@/types/track";
@@ -541,6 +541,12 @@ export function MobileFullscreenPlayer({ track, onClose, currentVersion }: Mobil
             animate={{ opacity: 1 }}
             transition={{ delay: 0.2 }}
           >
+            <div className="flex items-center justify-center gap-1.5 mb-1">
+              <span className="inline-flex items-center gap-1 bg-primary/15 text-primary px-2.5 py-0.5 rounded-full text-[11px] font-semibold">
+                <Sparkles className="w-3 h-3" />
+                Сгенерировано AI
+              </span>
+            </div>
             <div className="flex items-center justify-center gap-1.5 mb-0.5">
               <h2 className="font-display font-semibold text-[17px] leading-tight truncate tracking-tight text-foreground">
                 {track.title || "Без названия"}

--- a/src/index.css
+++ b/src/index.css
@@ -166,17 +166,17 @@ All colors MUST be HSL.
     --z-dropdown: 200;
     --z-toast: 300; /* Toasts/announcements — top of the world */
 
-    /* Section-specific accent colors - harmonized with primary */
-    --generate: 250 80% 60%;
-    --generate-glow: 250 80% 70%;
+    /* Section-specific accent colors - warm orange palette */
+    --generate: 20 100% 62%;
+    --generate-glow: 20 100% 50%;
     --library: 207 90% 54%;
     --library-glow: 207 90% 64%;
-    --projects: 175 70% 45%;
-    --projects-glow: 175 70% 55%;
+    --projects: 262 55% 70%;
+    --projects-glow: 262 55% 56%;
     --community: 330 75% 55%;
     --community-glow: 330 75% 65%;
-    --success: 160 70% 42%;
-    --success-glow: 160 70% 52%;
+    --success: 130 42% 64%;
+    --success-glow: 130 42% 50%;
     --warning: 38 95% 50%;
     --warning-glow: 38 95% 60%;
 
@@ -208,88 +208,88 @@ All colors MUST be HSL.
   }
 
   .dark {
-    /* Dark theme - Midnight + Aurora (MusicVerse 2026)
-       Palette: #070713 / #0f1424 / #1a2240 / aurora green #4ade80 */
-    --background: 240 46% 5%; /* #070713 */
-    --foreground: 220 30% 96%;
+    /* Dark theme - Warm Dark + Orange Accent (MusicVerse 2026 redesign)
+       Palette: #140F0C (bg) / #1D1611 (surface) / #FF7A3D (accent) / #FFB23E→#FF6B4A (gradient) */
+    --background: 24 30% 6%; /* #140F0C */
+    --foreground: 27 30% 94%; /* #F6EFE8 */
 
-    --card: 226 41% 10%; /* #0f1424 */
-    --card-foreground: 220 30% 96%;
+    --card: 24 22% 9%; /* #1D1611 */
+    --card-foreground: 27 30% 94%;
 
-    --popover: 226 41% 11%;
-    --popover-foreground: 220 30% 96%;
+    --popover: 24 22% 10%;
+    --popover-foreground: 27 30% 94%;
 
-    /* Primary - Aurora mint (signature accent, desaturated for Linear/Arc-style refinement) */
-    --primary: 152 42% 56%; /* #62b48a — muted mint, no neon */
-    --primary-foreground: 240 46% 5%;
+    /* Primary - Warm orange accent */
+    --primary: 20 100% 62%; /* #FF7A3D */
+    --primary-foreground: 20 60% 9%; /* #2A1206 */
 
-    --secondary: 227 32% 16%;
-    --secondary-foreground: 220 25% 92%;
+    --secondary: 24 22% 12%;
+    --secondary-foreground: 27 20% 88%;
 
-    --muted: 227 28% 13%;
-    --muted-foreground: 222 16% 60%;
+    --muted: 24 18% 10%;
+    --muted-foreground: 22 12% 55%; /* #9A8A7C */
 
-    --accent: 227 42% 18%; /* #1a2240 */
-    --accent-foreground: 152 42% 66%;
+    --accent: 24 30% 14%;
+    --accent-foreground: 20 100% 62%;
 
     --destructive: 0 72% 56%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 226 30% 18%;
-    --input: 226 30% 18%;
-    --ring: 152 42% 56%;
+    --border: 24 25% 15%; /* #302419 */
+    --input: 24 25% 15%;
+    --ring: 20 100% 62%;
 
-    /* Section-specific accent colors (Midnight + Aurora, refined) */
-    --generate: 152 42% 56%; /* aurora mint */
-    --generate-glow: 152 42% 44%;
-    --library: 199 70% 62%; /* cyan companion, desaturated */
+    /* Section-specific accent colors (warm palette) */
+    --generate: 20 100% 62%; /* warm orange */
+    --generate-glow: 20 100% 50%;
+    --library: 199 70% 62%;
     --library-glow: 199 70% 48%;
-    --projects: 262 55% 70%; /* indigo, softer */
+    --projects: 262 55% 70%;
     --projects-glow: 262 55% 56%;
     --community: 330 55% 68%;
     --community-glow: 330 55% 52%;
-    --success: 152 42% 56%;
-    --success-glow: 152 42% 44%;
-    --warning: 38 80% 62%;
-    --warning-glow: 38 80% 50%;
+    --success: 130 42% 64%; /* #8FD694 */
+    --success-glow: 130 42% 50%;
+    --warning: 38 95% 60%;
+    --warning-glow: 38 95% 48%;
 
-    /* Glassmorphism - Midnight glass */
-    --glass-bg: 240 46% 5% / 0.72;
-    --glass-border: 226 30% 22%;
-    --glass-shadow: 0 8px 32px 0 hsl(240 60% 2% / 0.55);
+    /* Glassmorphism - Warm glass */
+    --glass-bg: 24 30% 6% / 0.72;
+    --glass-border: 24 25% 18%;
+    --glass-shadow: 0 8px 32px 0 hsl(24 40% 3% / 0.55);
 
-    --gradient-primary: linear-gradient(135deg, hsl(152 42% 56%), hsl(199 70% 62%));
-    --gradient-card: linear-gradient(135deg, hsl(227 38% 12% / 0.85), hsl(240 46% 6% / 0.65));
-    --gradient-hero: linear-gradient(135deg, hsl(152 42% 56% / 0.12), hsl(262 55% 70% / 0.12));
+    --gradient-primary: linear-gradient(135deg, #FFB23E, #FF6B4A);
+    --gradient-card: linear-gradient(135deg, hsl(24 22% 11% / 0.85), hsl(24 30% 7% / 0.65));
+    --gradient-hero: linear-gradient(135deg, hsl(20 100% 62% / 0.12), hsl(340 60% 50% / 0.12));
     --gradient-telegram: linear-gradient(135deg, hsl(199 70% 62%), hsl(262 55% 70%));
-    --gradient-generate: linear-gradient(135deg, hsl(152 42% 56%), hsl(199 70% 62%));
-    --gradient-success: linear-gradient(135deg, hsl(152 42% 56%), hsl(160 45% 52%));
+    --gradient-generate: linear-gradient(135deg, #FFB23E, #FF6B4A);
+    --gradient-success: linear-gradient(135deg, #8FD694, #6BC476);
 
-    --shadow-glass: 0 4px 24px 0 hsl(240 60% 2% / 0.5);
-    --shadow-hover: 0 8px 32px 0 hsl(207 90% 54% / 0.2);
-    --shadow-glow: 0 0 40px 0 hsl(207 90% 54% / 0.35);
+    --shadow-glass: 0 4px 24px 0 hsl(24 40% 3% / 0.5);
+    --shadow-hover: 0 8px 32px 0 hsl(20 100% 50% / 0.2);
+    --shadow-glow: 0 0 40px 0 hsl(20 100% 50% / 0.35);
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     --transition-bounce: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 
-    --sidebar-background: 220 20% 6%;
-    --sidebar-foreground: 220 10% 95%;
-    --sidebar-primary: 207 90% 54%;
+    --sidebar-background: 24 20% 7%;
+    --sidebar-foreground: 27 10% 95%;
+    --sidebar-primary: 20 100% 62%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 220 15% 14%;
-    --sidebar-accent-foreground: 220 10% 95%;
-    --sidebar-border: 220 15% 18%;
-    --sidebar-ring: 207 90% 54%;
+    --sidebar-accent: 24 15% 14%;
+    --sidebar-accent-foreground: 27 10% 95%;
+    --sidebar-border: 24 15% 18%;
+    --sidebar-ring: 20 100% 62%;
 
     /* Dark-theme overrides for the Phase 1 semantic surfaces */
-    --surface-1: 226 41% 10%;
-    --surface-2: 227 32% 13%;
-    --surface-3: 227 28% 16%;
-    --overlay-scrim: 240 46% 5% / 0.7;
-    --ring-focus: hsl(152 42% 56% / 0.55);
-    --state-success: 152 42% 56%;
-    --state-success-foreground: 240 46% 5%;
+    --surface-1: 24 22% 9%; /* #1D1611 */
+    --surface-2: 24 18% 11%;
+    --surface-3: 24 18% 14%;
+    --overlay-scrim: 24 30% 6% / 0.7;
+    --ring-focus: hsl(20 100% 62% / 0.55);
+    --state-success: 130 42% 64%;
+    --state-success-foreground: 24 30% 6%;
     --state-warning: 38 95% 60%;
-    --state-warning-foreground: 240 46% 5%;
+    --state-warning-foreground: 24 30% 6%;
     --state-danger: 0 72% 56%;
     --state-danger-foreground: 0 0% 100%;
     --state-info: 207 90% 60%;

--- a/src/pages/Artists.tsx
+++ b/src/pages/Artists.tsx
@@ -171,6 +171,14 @@ export default function Artists() {
                           </h3>
                         </div>
 
+                        {artist.is_ai_generated && (
+                          <div className="flex items-center gap-2 mt-1">
+                            <span className="inline-flex items-center gap-1 bg-primary/15 text-primary px-2 py-0.5 rounded-full text-[11px] font-semibold">
+                              AI АРТИСТ
+                            </span>
+                          </div>
+                        )}
+
                         {artist.bio && <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{artist.bio}</p>}
 
                         {artist.genre_tags && artist.genre_tags.length > 0 && (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,6 +32,8 @@ import { ContinueDraftCard } from "@/components/home/ContinueDraftCard";
 import { CreativePresetsSection } from "@/components/home/CreativePresetsSection";
 import { DiscoverTabs } from "@/components/home/DiscoverTabs";
 import { YouStrip } from "@/components/home/YouStrip";
+import { CommunityTrending } from "@/components/home/CommunityTrending";
+import { AiSuggestions } from "@/components/home/AiSuggestions";
 import { Section, sectionTokens } from "@/components/layout/Section";
 
 const GenerateSheet = lazy(() => import("@/components/GenerateSheet").then((m) => ({ default: m.GenerateSheet })));
@@ -129,6 +131,21 @@ const Index = () => {
     </Section>
   );
 
+  const trendingBlock = (
+    <Section sectionId="trending" density="comfortable" tone="plain">
+      <CommunityTrending
+        tracks={popularTracks}
+        onTrackClick={handleTrackClick}
+      />
+    </Section>
+  );
+
+  const aiSuggestBlock = (
+    <Section sectionId="ai-suggest" density="comfortable" tone="plain">
+      <AiSuggestions onCreateClick={handleCreate} />
+    </Section>
+  );
+
   const youBlock = user ? (
     <Section sectionId="you" eyebrow="Вы" title="Ваш прогресс" density="compact" tone="subtle">
       <YouStrip />
@@ -176,7 +193,9 @@ const Index = () => {
             <div className={cn("xl:col-span-8 min-w-0", sectionTokens.blockGap)}>
               {heroBlock}
               {createBlock}
+              {trendingBlock}
               {discoverBlock}
+              {aiSuggestBlock}
             </div>
 
             <aside className={cn("xl:col-span-4 min-w-0 xl:sticky xl:top-8", sectionTokens.blockGap)}>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,9 +40,9 @@ export default {
     },
     extend: {
       fontFamily: {
-        sans: ['"DM Sans"', "Inter", "system-ui", "sans-serif"],
+        sans: ['"Onest"', "Inter", "system-ui", "sans-serif"],
         mono: ['"JetBrains Mono"', "Roboto Mono", "monospace"],
-        display: ['"Space Grotesk"', '"DM Sans"', "system-ui", "sans-serif"],
+        display: ['"Unbounded"', '"Onest"', "system-ui", "sans-serif"],
       },
       fontSize: {
         // Professional Typography Scale (from 032-professional-ui spec)
@@ -203,7 +203,7 @@ export default {
         spring: "var(--ease-spring)",
       },
       backgroundImage: {
-        "gradient-telegram": "linear-gradient(135deg, hsl(207 90% 54%), hsl(250 80% 60%))",
+        "gradient-telegram": "linear-gradient(135deg, hsl(199 70% 62%), hsl(262 55% 70%))",
         "gradient-primary": "var(--gradient-primary)",
         "gradient-card": "var(--gradient-card)",
         "gradient-hero": "var(--gradient-hero)",
@@ -212,8 +212,8 @@ export default {
       },
       boxShadow: {
         glow: "var(--shadow-glow)",
-        "glow-sm": "0 0 15px 0 hsl(207 90% 54% / 0.2)",
-        "glow-lg": "0 0 50px 0 hsl(207 90% 54% / 0.4)",
+        "glow-sm": "0 0 15px 0 hsl(20 100% 62% / 0.2)",
+        "glow-lg": "0 0 50px 0 hsl(20 100% 62% / 0.4)",
         "glow-generate": "0 0 30px 0 hsl(var(--generate) / 0.4)",
         // Design system elevation levels (feature 032-professional-ui)
         "elevation-0": shadows.none,
@@ -266,10 +266,10 @@ export default {
         },
         "pulse-glow": {
           "0%, 100%": {
-            boxShadow: "0 0 20px hsl(207 90% 54% / 0.4)",
+            boxShadow: "0 0 20px hsl(20 100% 62% / 0.4)",
           },
           "50%": {
-            boxShadow: "0 0 30px hsl(207 90% 54% / 0.6)",
+            boxShadow: "0 0 30px hsl(20 100% 62% / 0.6)",
           },
         },
         shimmer: {


### PR DESCRIPTION
- Replace fonts (DM Sans/Space Grotesk → Onest/Unbounded) with Cyrillic support
- Rewrite dark theme color tokens from cold blue to warm orange palette
- Add CommunityTrending and AiSuggestions components to home page
- Update generation progress stage labels with Russian subtitles
- Add "Сгенерировано AI" badge to fullscreen player
- Add "AI АРТИСТ" badge to Artists page

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Zqi123F29a73cm3MjN94A