### PR TITLE
fix: improve mobile UX — auto bottom-sheet dialogs, touch targets, ARIA, nav sizing

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -141,14 +141,14 @@ export const BottomNavigation = memo(function BottomNavigation() {
                 />
                 <item.icon
                   className={cn(
-                    "relative w-[18px] h-[18px] transition-transform duration-200",
+                    "relative w-5 h-5 transition-transform duration-200",
                     active && "text-primary",
                   )}
                   strokeWidth={active ? 2.4 : 2}
                 />
                 <span
                   className={cn(
-                    "relative text-[10px] leading-none tracking-tight transition-all duration-200",
+                    "relative text-[11px] leading-none tracking-tight transition-all duration-200",
                     typographyClass.caption,
                     active ? "font-semibold text-foreground" : "font-medium",
                   )}

--- a/src/components/generate-form/AudioActionDialog.tsx
+++ b/src/components/generate-form/AudioActionDialog.tsx
@@ -641,7 +641,7 @@ export function AudioActionDialog({
         <div className="space-y-3">
           {/* Audio Player - Compact */}
           <div className="flex items-center gap-2 p-2 rounded-lg bg-muted/50 border">
-            <Button type="button" size="icon" variant="ghost" onClick={togglePlayback} className="h-9 w-9 shrink-0">
+            <Button type="button" size="icon" variant="ghost" onClick={togglePlayback} className="h-11 w-11 shrink-0">
               {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
             </Button>
             <div className="flex-1 min-w-0">
@@ -695,7 +695,7 @@ export function AudioActionDialog({
                   type="button"
                   variant="outline"
                   size="sm"
-                  className="w-full h-9 gap-2 text-xs"
+                  className="w-full h-11 gap-2 text-xs"
                   onClick={extractLyrics}
                   disabled={isExtractingLyrics}
                 >
@@ -746,11 +746,11 @@ export function AudioActionDialog({
             )}
 
             <div className="flex gap-2">
-              <Button type="button" variant="outline" size="sm" onClick={handleRemove} className="flex-1 h-9">
+              <Button type="button" variant="outline" size="sm" onClick={handleRemove} className="flex-1 h-11">
                 Отменить
               </Button>
               {analysisResult && (
-                <Button type="button" variant="secondary" size="sm" onClick={handleConfirm} className="flex-1 h-9">
+                <Button type="button" variant="secondary" size="sm" onClick={handleConfirm} className="flex-1 h-11">
                   В форму генерации
                 </Button>
               )}

--- a/src/components/generate-form/LyricsVisualEditor.tsx
+++ b/src/components/generate-form/LyricsVisualEditor.tsx
@@ -390,7 +390,7 @@ export function LyricsVisualEditor({ value, onChange, onAIGenerate }: LyricsVisu
           <div className="flex items-center gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button type="button" variant="default" size="sm" className="gap-2 h-9 shadow-md">
+                <Button type="button" variant="default" size="sm" className="gap-2 h-11 shadow-md">
                   <Plus className="w-4 h-4" />
                   Добавить
                   <ChevronDown className="w-3 h-3 opacity-70" />
@@ -426,7 +426,7 @@ export function LyricsVisualEditor({ value, onChange, onAIGenerate }: LyricsVisu
             </DropdownMenu>
 
             {onAIGenerate && (
-              <Button type="button" variant="secondary" size="sm" onClick={onAIGenerate} className="gap-2 h-9">
+              <Button type="button" variant="secondary" size="sm" onClick={onAIGenerate} className="gap-2 h-11">
                 <Sparkles className="w-4 h-4" />
                 AI Лирика
               </Button>
@@ -576,7 +576,7 @@ export function LyricsVisualEditor({ value, onChange, onAIGenerate }: LyricsVisu
                                     type="button"
                                     variant="ghost"
                                     size="icon"
-                                    className="h-8 w-8 text-emerald-500 hover:text-emerald-600 hover:bg-emerald-500/10"
+                                    className="h-8 w-8 min-w-[44px] min-h-[44px] text-emerald-500 hover:text-emerald-600 hover:bg-emerald-500/10"
                                     onClick={() => handleSaveEdit(section.id)}
                                   >
                                     <Check className="w-4 h-4" />
@@ -587,13 +587,13 @@ export function LyricsVisualEditor({ value, onChange, onAIGenerate }: LyricsVisu
                                       onResult={(text) => handleVoiceInput(section.id, text)}
                                       context="lyrics"
                                       size="icon"
-                                      className="h-8 w-8"
+                                      className="h-8 w-8 min-w-[44px] min-h-[44px]"
                                     />
                                     <Button
                                       type="button"
                                       variant="ghost"
                                       size="icon"
-                                      className="h-8 w-8 hover:bg-primary/10"
+                                      className="h-8 w-8 min-w-[44px] min-h-[44px] hover:bg-primary/10"
                                       onClick={() => setEditingId(section.id)}
                                     >
                                       <Edit2 className="w-4 h-4" />
@@ -602,7 +602,7 @@ export function LyricsVisualEditor({ value, onChange, onAIGenerate }: LyricsVisu
                                       type="button"
                                       variant="ghost"
                                       size="icon"
-                                      className="h-8 w-8 hover:bg-primary/10"
+                                      className="h-8 w-8 min-w-[44px] min-h-[44px] hover:bg-primary/10"
                                       onClick={() => handleDuplicateSection(section.id)}
                                       title="Дублировать секцию"
                                     >
@@ -614,7 +614,7 @@ export function LyricsVisualEditor({ value, onChange, onAIGenerate }: LyricsVisu
                                   type="button"
                                   variant="ghost"
                                   size="icon"
-                                  className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                                  className="h-8 w-8 min-w-[44px] min-h-[44px] text-destructive hover:text-destructive hover:bg-destructive/10"
                                   onClick={() => handleDeleteSection(section.id)}
                                 >
                                   <Trash2 className="w-4 h-4" />

--- a/src/components/generate-form/SmartPromptSuggestions.tsx
+++ b/src/components/generate-form/SmartPromptSuggestions.tsx
@@ -176,7 +176,7 @@ export function SmartPromptSuggestions({
                   variant="outline"
                   size="sm"
                   onClick={() => onSelectPrompt(template.prompt)}
-                  className="chip-button h-9 px-3 text-xs gap-1.5 flex-shrink-0 whitespace-nowrap hover:bg-primary/10 hover:text-primary hover:border-primary"
+                  className="chip-button h-10 min-h-[44px] px-3 text-xs gap-1.5 flex-shrink-0 whitespace-nowrap hover:bg-primary/10 hover:text-primary hover:border-primary"
                 >
                   <Icon className="h-3.5 w-3.5" />
                   {template.title}

--- a/src/components/navigation/MenuSearch.tsx
+++ b/src/components/navigation/MenuSearch.tsx
@@ -48,15 +48,16 @@ export const MenuSearch = memo(function MenuSearch({ items, onNavigate, isActive
   };
 
   return (
-    <div className="relative mb-4">
+    <div className="relative mb-4" role="search" aria-label="Поиск по меню">
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" aria-hidden="true" />
         <Input
-          type="text"
+          type="search"
           placeholder="Поиск по меню..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="pl-10 pr-10 h-10 bg-muted/50 border-border/50 rounded-xl"
+          aria-label="Поиск по меню"
         />
         <AnimatePresence>
           {query && (

--- a/src/components/navigation/MoreMenuSheet.tsx
+++ b/src/components/navigation/MoreMenuSheet.tsx
@@ -173,7 +173,7 @@ export function MoreMenuSheet({ open, onOpenChange }: MoreMenuSheetProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="rounded-t-3xl max-h-[85vh] overflow-y-auto pb-safe">
+      <SheetContent side="bottom" className="rounded-t-3xl max-h-[85vh] overflow-y-auto pb-safe" aria-label="Дополнительное меню">
         <SheetHeader className="pb-2">
           <SheetTitle className="flex items-center gap-2 text-lg">
             <Grid3X3 className="w-5 h-5 text-primary" />

--- a/src/components/navigation/QuickActionsBar.tsx
+++ b/src/components/navigation/QuickActionsBar.tsx
@@ -80,7 +80,7 @@ export const QuickActionsBar = memo(function QuickActionsBar({ onClose }: QuickA
   };
 
   return (
-    <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-hide">
+    <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-hide" role="toolbar" aria-label="Быстрые действия">
       {quickActions.map((action, index) => {
         const Icon = action.icon;
         return (

--- a/src/components/payments/PaymentButton.tsx
+++ b/src/components/payments/PaymentButton.tsx
@@ -39,7 +39,7 @@ export function PaymentButton({
       return (
         <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} className="flex items-center gap-3">
           <motion.div
-            className={cn("w-8 h-8 rounded-full flex items-center justify-center", surface.medium)}
+            className={cn("w-8 h-8 min-w-[44px] min-h-[44px] rounded-full flex items-center justify-center", surface.medium)}
             animate={{ rotate: [0, 360] }}
             transition={{ duration: 0.5 }}
           >

--- a/src/components/studio/unified/SortableTrackList.tsx
+++ b/src/components/studio/unified/SortableTrackList.tsx
@@ -201,7 +201,7 @@ export const SortableTrackList = memo(function SortableTrackList({
       const result: Record<string, StemTranscriptionData> = {};
 
       if (stemsError || !stems?.length) {
-        console.log("[SortableTrackList] No stems found for", sourceTrackId, stemTypes);
+        logger.info("[SortableTrackList] No stems found for", { sourceTrackId, stemTypes });
         // Try to fetch transcriptions directly by track_id for 'main' type
         if (stemTypes.includes("main")) {
           const { data: mainTrans } = await supabase
@@ -245,16 +245,14 @@ export const SortableTrackList = memo(function SortableTrackList({
       }
 
       if (!transcriptions?.length) {
-        console.log("[SortableTrackList] No transcriptions found for stemIds:", stemIds);
+        logger.info("[SortableTrackList] No transcriptions found for stemIds", { stemIds });
         return result;
       }
 
-      console.log(
-        "[SortableTrackList] Found transcriptions:",
-        transcriptions.length,
-        "for stems:",
-        stems.map((s) => s.stem_type),
-      );
+      logger.info("[SortableTrackList] Found transcriptions", {
+        count: transcriptions.length,
+        stemTypes: stems.map((s) => s.stem_type),
+      });
 
       // Build map: stemType -> transcription data (reuse result already declared above)
 
@@ -290,7 +288,8 @@ export const SortableTrackList = memo(function SortableTrackList({
           durationSeconds: trans.duration_seconds ? Number(trans.duration_seconds) : null,
         };
 
-        console.log("[SortableTrackList] Mapped transcription for", stem.stem_type, ":", {
+        logger.info("[SortableTrackList] Mapped transcription for", {
+          stemType: stem.stem_type,
           hasNotes: !!normalizedNotes?.length,
           hasMidi: !!trans.midi_url,
           hasPdf: !!trans.pdf_url,

--- a/src/components/track/QuickLikeButton.tsx
+++ b/src/components/track/QuickLikeButton.tsx
@@ -80,8 +80,8 @@ export const QuickLikeButton = memo(function QuickLikeButton({
   );
 
   const sizeClasses = {
-    sm: "w-7 h-7",
-    md: "w-9 h-9",
+    sm: "w-7 h-7 min-w-[44px] min-h-[44px]",
+    md: "w-9 h-9 min-w-[44px] min-h-[44px]",
     lg: "w-11 h-11",
   };
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -43,12 +43,8 @@ interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof Dialo
    * If true, render as a native bottom-sheet on mobile (<640px) — slide-up from bottom,
    * full width, drag-handle, safe-area-bottom padding, swipe-to-dismiss.
    *
-   * NOTE: This is opt-in (mobileSheet={true}) rather than auto-detected to avoid breaking
-   * existing dialogs that rely on centered/constrained geometry. For true mobile-first UX,
-   * consider using the Drawer component from vaul which auto-detects viewport.
-   *
-   * Future improvement: Auto-detect mobile viewport and make bottom sheet the default
-   * behavior with a desktopMode opt-out prop. See analysis: 96 dialogs exist, 0 use this prop.
+   * Enabled by default: renders as native bottom-sheet on mobile (<640px).
+   * Set mobileSheet={false} to force centered modal on all viewports.
    */
   mobileSheet?: boolean;
 }
@@ -140,7 +136,7 @@ function useSwipeDownToClose(
 }
 
 const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
-  ({ className, children, hideTitle = false, accessibleTitle = "Диалоговое окно", mobileSheet = false, ...props }, ref) => {
+  ({ className, children, hideTitle = false, accessibleTitle = "Диалоговое окно", mobileSheet = true, ...props }, ref) => {
     // Check if this is a fullscreen dialog (has h-[100dvh], h-screen, or h-[100vh] in className)
     const isFullscreen =
       className?.includes("h-[100dvh]") || className?.includes("h-screen") || className?.includes("h-[100vh]");


### PR DESCRIPTION
- Enable mobileSheet by default in DialogContent for native bottom-sheet on mobile
- Fix touch targets < 44px in QuickLikeButton, PaymentButton, LyricsVisualEditor, AudioActionDialog
- Increase generate-form buttons from h-9 to h-11 (44px minimum)
- Add ARIA labels to MenuSearch, QuickActionsBar, MoreMenuSheet
- Increase BottomNavigation icons to 20px and labels to 11px
- Replace console.log with logger in SortableTrackList

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lcds598TJGsEEpejQqS4bu