### PR TITLE
fix: break circular dep causing TDZ crash in analytics page

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -5,7 +5,8 @@ import { BarChart3, Music, Play, Heart, TrendingUp, Calendar, CheckCircle2, XCir
 import { useUserStats } from "@/hooks/useUserStats";
 import { motion } from "@/lib/motion";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EngagementChart, GenreDistributionChart } from "@/components/analytics";
+import { EngagementChart } from "@/components/analytics/EngagementChart";
+import { GenreDistributionChart } from "@/components/analytics/GenreDistributionChart";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DesktopDashboardLayout } from "@/components/layout/desktop";
 


### PR DESCRIPTION
## Summary

- Replace barrel import `from "@/components/analytics"` with direct file imports in `src/pages/Analytics.tsx`
- This breaks the circular dependency chain that caused `Cannot access 'F' before initialization` TDZ error at runtime on Lovable preview

## Test plan

- [x] Build succeeds locally (`vite build`)
- [x] No `page-analytics` chunk generated (Vite auto-names it, avoiding the circular dep)
- [ ] Lovable preview loads without TDZ crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrrzSuCxXRrBJAW5cuwjdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrrzSuCxXRrBJAW5cuwjdN)_