### PR TITLE
feat: add scroll-reveal and micro-interactions to mobile home ui

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -134,8 +134,9 @@ export const BottomNavigation = memo(function BottomNavigation() {
                     className={cn(
                       "relative flex items-center justify-center w-12 h-12 rounded-2xl",
                       "bg-gradient-to-br from-primary to-primary/80 text-primary-foreground",
-                      "aurora-glow",
-                      "active:scale-92 hover:scale-105 transition-all duration-200",
+                      "aurora-glow glow-primary motion-reduce:animate-none",
+                      "active:scale-90 hover:scale-105 transition-transform duration-300",
+                      "[transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]",
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                       activeGenCount > 0 && "sheen ring-2 ring-primary/40 ring-offset-2 ring-offset-background",
                     )}
@@ -178,23 +179,32 @@ export const BottomNavigation = memo(function BottomNavigation() {
                 aria-current={active ? "page" : undefined}
                 title={item.label}
               >
-                {/* Subtle pill indicator behind icon when active */}
+                {/* Subtle pill indicator behind icon when active — bounce-eased pop */}
                 <span
                   className={cn(
-                    "absolute top-1 h-7 w-10 rounded-full bg-primary/12 ring-1 ring-primary/25 transition-all duration-200",
+                    "absolute top-1 h-7 w-10 rounded-full bg-primary/12 ring-1 ring-primary/25",
+                    "transition-all duration-300 [transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]",
+                    "motion-reduce:transition-none",
                     active ? "opacity-100 scale-100" : "opacity-0 scale-75",
                   )}
                   aria-hidden
                 />
                 <item.icon
-                  className={cn("relative w-5 h-5 transition-transform duration-200", active && "text-primary")}
+                  className={cn(
+                    "relative w-5 h-5 transition-transform duration-300",
+                    "[transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]",
+                    "motion-reduce:transition-none",
+                    active && "text-primary scale-110 -translate-y-0.5",
+                  )}
                   strokeWidth={active ? 2.4 : 2}
                 />
                 <span
                   className={cn(
-                    "relative transition-all duration-200",
+                    "relative transition-all duration-300",
+                    "[transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]",
+                    "motion-reduce:transition-none",
                     typographyClass.caption,
-                    active ? "font-semibold text-foreground" : "font-medium",
+                    active ? "font-semibold text-foreground -translate-y-0.5" : "font-medium",
                   )}
                 >
                   {item.label}

--- a/src/components/generate-form/FormSection.tsx
+++ b/src/components/generate-form/FormSection.tsx
@@ -2,21 +2,105 @@
  * FormSection - Visual container for form sections
  * Provides consistent spacing, background, and grouping
  * Uses design system tokens (Spec 032)
+ *
+ * Optional `step`/`title`/`icon` props render a numbered group header and
+ * promote the section to a distinct card (border + soft surface + left accent),
+ * so multi-group forms (e.g. the advanced/custom generation form) read as a
+ * sequence of clearly separated steps instead of one continuous scroll.
  */
 
 import { memo, ReactNode } from "react";
+import { motion } from "@/lib/motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { cn } from "@/lib/utils";
 import { glass } from "@/lib/glass";
+
+export type FormSectionTone = "default" | "style" | "lyrics" | "voice" | "settings";
+
+const TONE_ACCENT: Record<FormSectionTone, string> = {
+  default: "bg-muted/60 text-foreground/80 border-border/50",
+  style: "bg-primary/10 text-primary border-primary/20",
+  lyrics: "bg-violet-500/10 text-violet-400 border-violet-500/20",
+  voice: "bg-pink-500/10 text-pink-400 border-pink-500/20",
+  settings: "bg-slate-500/10 text-slate-400 border-slate-500/20",
+};
+
+const TONE_BAR: Record<FormSectionTone, string> = {
+  default: "before:bg-border/60",
+  style: "before:bg-primary/40",
+  lyrics: "before:bg-violet-500/40",
+  voice: "before:bg-pink-500/40",
+  settings: "before:bg-slate-500/40",
+};
 
 interface FormSectionProps {
   children: ReactNode;
   className?: string;
   /** Add subtle background to distinguish section */
   elevated?: boolean;
+  /** Step number shown in a small badge next to the title (1-indexed) */
+  step?: number;
+  /** Group title — rendering it promotes the section to a bordered, numbered card */
+  title?: string;
+  /** Optional one-line description under the title */
+  description?: string;
+  /** Optional icon rendered inside the step badge (replaces the number) */
+  icon?: ReactNode;
+  /** Muted accent used for the step badge + left edge bar */
+  tone?: FormSectionTone;
 }
 
-export const FormSection = memo(function FormSection({ children, className, elevated = false }: FormSectionProps) {
-  return <div className={cn("space-y-2.5", elevated && cn("p-3 rounded-xl", glass.subtle), className)}>{children}</div>;
+export const FormSection = memo(function FormSection({
+  children,
+  className,
+  elevated = false,
+  step,
+  title,
+  description,
+  icon,
+  tone = "default",
+}: FormSectionProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const isGroup = Boolean(title);
+
+  return (
+    <motion.div
+      className={cn(
+        "space-y-2.5",
+        (elevated || isGroup) && cn("p-3.5 rounded-2xl", glass.subtle),
+        isGroup &&
+          cn(
+            "relative pl-4 before:absolute before:left-2 before:top-3.5 before:bottom-3.5",
+            "before:w-[3px] before:rounded-full",
+            TONE_BAR[tone],
+          ),
+        className,
+      )}
+      initial={prefersReducedMotion ? undefined : { opacity: 0, y: 10 }}
+      whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+    >
+      {isGroup && (
+        <div className="flex items-start gap-2.5 mb-1">
+          <span
+            className={cn(
+              "shrink-0 flex items-center justify-center w-6 h-6 rounded-lg border text-[11px] font-bold",
+              TONE_ACCENT[tone],
+            )}
+            aria-hidden
+          >
+            {icon ?? step}
+          </span>
+          <div className="min-w-0 flex-1 pt-px">
+            <h3 className="text-sm font-semibold text-foreground leading-tight">{title}</h3>
+            {description && <p className="text-[11px] text-muted-foreground leading-snug mt-0.5">{description}</p>}
+          </div>
+        </div>
+      )}
+      {children}
+    </motion.div>
+  );
 });
 
 /**
@@ -24,5 +108,5 @@ export const FormSection = memo(function FormSection({ children, className, elev
  */
 export const FormDivider = memo(function FormDivider({ className }: { className?: string }) {
   // Invisible spacer — symmetric vertical rhythm without harsh hairlines.
-  return <div className={cn("h-4", className)} aria-hidden />;
+  return <div className={cn("h-3", className)} aria-hidden />;
 });

--- a/src/components/generate-form/GenerateFormCustom.tsx
+++ b/src/components/generate-form/GenerateFormCustom.tsx
@@ -3,6 +3,7 @@ import { TitleSection, StyleSection, VocalsToggle, LyricsSectionAdvanced, Privac
 import { AdvancedSettings } from "./AdvancedSettings";
 import { FormSection, FormDivider } from "./FormSection";
 import { CustomVoicePicker } from "@/components/voice-clone/CustomVoicePicker";
+import { FileText, Palette, Mic2, AudioLines, Settings2 } from "@/lib/icons";
 
 interface GenerateFormCustomProps {
   title: string;
@@ -89,14 +90,20 @@ export function GenerateFormCustom({
       transition={{ duration: 0.2, ease: "easeInOut" }}
     >
       {/* ========== BASIC INFO GROUP ========== */}
-      <FormSection>
+      <FormSection step={1} title="Основное" icon={<FileText className="w-3.5 h-3.5" />} tone="default">
         <TitleSection title={title} onTitleChange={onTitleChange} />
       </FormSection>
 
       <FormDivider />
 
       {/* ========== STYLE & VOCALS GROUP ========== */}
-      <FormSection elevated>
+      <FormSection
+        step={2}
+        title="Стиль и вокал"
+        description="Опишите звучание и выберите, нужен ли голос"
+        icon={<Palette className="w-3.5 h-3.5" />}
+        tone="style"
+      >
         <StyleSection
           style={style}
           onStyleChange={onStyleChange}
@@ -112,7 +119,13 @@ export function GenerateFormCustom({
       {hasVocals && (
         <>
           <FormDivider />
-          <FormSection>
+          <FormSection
+            step={3}
+            title="Текст песни"
+            description="Структурируйте по секциям или напишите текст целиком"
+            icon={<Mic2 className="w-3.5 h-3.5" />}
+            tone="lyrics"
+          >
             <LyricsSectionAdvanced
               lyrics={lyrics}
               onLyricsChange={onLyricsChange}
@@ -126,7 +139,13 @@ export function GenerateFormCustom({
           {onCustomVoiceIdChange && (
             <>
               <FormDivider />
-              <FormSection>
+              <FormSection
+                step={4}
+                title="Кастомный голос"
+                description="Опционально — клонированный голос для вокала"
+                icon={<AudioLines className="w-3.5 h-3.5" />}
+                tone="voice"
+              >
                 <CustomVoicePicker value={customVoiceId ?? null} onChange={onCustomVoiceIdChange} />
               </FormSection>
             </>
@@ -137,7 +156,13 @@ export function GenerateFormCustom({
       {/* ========== SETTINGS GROUP ========== */}
       <FormDivider />
 
-      <FormSection>
+      <FormSection
+        step={hasVocals ? (onCustomVoiceIdChange ? 5 : 4) : 3}
+        title="Настройки"
+        description="Приватность и точная настройка генерации"
+        icon={<Settings2 className="w-3.5 h-3.5" />}
+        tone="settings"
+      >
         {onIsPublicChange && (
           <PrivacyToggle isPublic={isPublic} onIsPublicChange={onIsPublicChange} canMakePrivate={canMakePrivate} />
         )}

--- a/src/components/generate-form/LyricsVisualEditorCompact.tsx
+++ b/src/components/generate-form/LyricsVisualEditorCompact.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Trash2, Sparkles, ChevronDown, Eraser, CornerDownLeft } from "@/lib/icons";
+import { Plus, Trash2, Sparkles, ChevronDown, ChevronUp, Eraser, CornerDownLeft, Wand2, PenLine } from "@/lib/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,6 +16,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuLabel,
 } from "@/components/ui/dropdown-menu";
+import { motion, AnimatePresence } from "@/lib/motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { cn } from "@/lib/utils";
 
 interface LyricSection {
@@ -197,7 +199,6 @@ function pushSnapshot(snap: SyncSnapshot) {
   if (arr.length > MAX_SNAPSHOTS) arr.splice(0, arr.length - MAX_SNAPSHOTS);
 }
 
-
 export function LyricsVisualEditorCompact({ value, onChange, onAIGenerate }: LyricsVisualEditorCompactProps) {
   const [sections, setSections] = useState<LyricSection[]>(() => parseLyrics(value));
   // Track the last lyrics string we emitted, so external changes (mode switch, AI, templates)
@@ -295,27 +296,50 @@ export function LyricsVisualEditorCompact({ value, onChange, onAIGenerate }: Lyr
     updateSections(sections.filter((s) => s.id !== id));
   };
 
+  const moveSection = (id: string, direction: "up" | "down") => {
+    const index = sections.findIndex((s) => s.id === id);
+    if (index === -1) return;
+    const targetIndex = direction === "up" ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= sections.length) return;
+    const next = [...sections];
+    [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+    updateSections(next);
+  };
+
   const applyTemplate = (sectionTypes: string[]) => {
     updateSections(applyTemplateToSections(sections, sectionTypes));
   };
 
   const charCount = useMemo(() => value.replace(/\[.*?\]/g, "").trim().length, [value]);
+  const prefersReducedMotion = useReducedMotion();
+  const sectionRefs = useRef<Record<string, HTMLTextAreaElement | null>>({});
+
+  const scrollToSection = (id: string) => {
+    const el = sectionRefs.current[id];
+    if (!el) return;
+    el.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "center" });
+    el.focus();
+  };
 
   return (
     <div className="space-y-2">
-      {/* Timeline - compact badges */}
+      {/* Timeline - clickable badges, jump to section */}
       {sections.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {sections.map((section) => {
             const typeInfo = SECTION_TYPES.find((t) => t.value === section.type);
             return (
-              <Badge
-                key={section.id}
-                variant="outline"
-                className={cn("text-[10px] px-1.5 py-0 h-5 cursor-default", typeInfo?.color)}
-              >
-                {typeInfo?.icon} {typeInfo?.label}
-              </Badge>
+              <button key={section.id} type="button" onClick={() => scrollToSection(section.id)}>
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "text-[10px] px-1.5 py-0 h-5 cursor-pointer transition-transform active:scale-95 hover:brightness-110",
+                    typeInfo?.color,
+                  )}
+                >
+                  {typeInfo?.icon} {typeInfo?.label}
+                </Badge>
+              </button>
             );
           })}
         </div>
@@ -323,101 +347,164 @@ export function LyricsVisualEditorCompact({ value, onChange, onAIGenerate }: Lyr
 
       {/* Sections */}
       <div className="space-y-2 max-h-[280px] overflow-y-auto">
-        {sections.map((section) => {
-          const typeInfo = SECTION_TYPES.find((t) => t.value === section.type);
-          return (
-            <div
-              key={section.id}
-              className={cn(
-                "rounded-lg border border-border/40 overflow-hidden",
-                "bg-gradient-to-br from-muted/30 to-transparent",
+        {sections.length === 0 && (
+          <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-4 text-center space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Пока нет ни одной секции. Начните с шаблона или добавьте секцию вручную.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-1.5">
+              {QUICK_TEMPLATES.map((t) => (
+                <Button
+                  key={t.name}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9 min-h-[44px] px-3 text-xs gap-1.5 rounded-full"
+                  onClick={() => applyTemplate(t.sections)}
+                >
+                  <span aria-hidden>{t.icon}</span>
+                  {t.name}
+                </Button>
+              ))}
+              {onAIGenerate && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9 min-h-[44px] px-3 text-xs gap-1.5 rounded-full border-dashed border-primary/40 text-primary hover:text-primary hover:bg-primary/10"
+                  onClick={onAIGenerate}
+                >
+                  <Wand2 className="w-3.5 h-3.5" />
+                  Создать с AI
+                </Button>
               )}
-            >
-              {/* Section header */}
-              <div className="flex items-center justify-between gap-2 px-2 py-1.5 bg-muted/30">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label={`Тип секции: ${typeInfo?.label}`}
-                      className={cn(
-                        "flex items-center gap-1 text-xs font-medium rounded-md px-2 py-1 min-h-[32px]",
-                        typeInfo?.color,
-                      )}
-                    >
-                      <span aria-hidden>{typeInfo?.icon}</span>
-                      <span>{typeInfo?.label}</span>
-                      <ChevronDown className="w-3 h-3 opacity-60" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="min-w-[140px]">
-                    {SECTION_TYPES.map((t) => (
-                      <DropdownMenuItem
-                        key={t.value}
-                        onClick={() => changeSectionType(section.id, t.value)}
-                        className={cn("text-xs", section.type === t.value && "bg-primary/10")}
-                      >
-                        <span className="mr-2">{t.icon}</span>
-                        {t.label}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-
-                <div className="flex items-center gap-0.5">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Добавить строку"
-                    className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-primary"
-                    onClick={() =>
-                      updateSectionContent(
-                        section.id,
-                        section.content ? section.content + "\n" : "",
-                      )
-                    }
-                  >
-                    <CornerDownLeft className="w-4 h-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Очистить секцию"
-                    disabled={!section.content}
-                    className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-foreground disabled:opacity-40"
-                    onClick={() => updateSectionContent(section.id, "")}
-                  >
-                    <Eraser className="w-4 h-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Удалить секцию"
-                    className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive"
-                    onClick={() => deleteSection(section.id)}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
-                </div>
-              </div>
-
-              {/* Content */}
-              <Textarea
-                value={section.content}
-                onChange={(e) => updateSectionContent(section.id, e.target.value)}
-                placeholder="Текст секции — каждая строка с новой строки..."
-                rows={3}
-                data-section-id={section.id}
-                className="border-0 rounded-none bg-transparent text-sm leading-relaxed resize-none focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/60"
-              />
-              <div className="flex items-center justify-between px-2 py-1 text-[10px] text-muted-foreground/70 bg-muted/10 border-t border-border/30">
-                <span>
-                  {section.content.split("\n").filter((l) => l.trim()).length} стр · {section.content.length} симв
-                </span>
-              </div>
             </div>
-          );
-        })}
+          </div>
+        )}
+
+        <AnimatePresence initial={false}>
+          {sections.map((section, index) => {
+            const typeInfo = SECTION_TYPES.find((t) => t.value === section.type);
+            return (
+              <motion.div
+                key={section.id}
+                layout={prefersReducedMotion ? undefined : "position"}
+                initial={prefersReducedMotion ? undefined : { opacity: 0, y: -8, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.97 }}
+                transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+                className={cn(
+                  "relative rounded-lg border border-border/40 overflow-hidden pl-1",
+                  "bg-gradient-to-br from-muted/30 to-transparent",
+                )}
+              >
+                {/* Left accent bar matching section type */}
+                <div className={cn("absolute left-0 top-0 bottom-0 w-1", typeInfo?.color.split(" ")[0])} aria-hidden />
+
+                {/* Section header */}
+                <div className="flex items-center justify-between gap-2 px-2 py-1.5 bg-muted/30">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={`Тип секции: ${typeInfo?.label}`}
+                        className={cn(
+                          "flex items-center gap-1 text-xs font-medium rounded-md px-2 py-1 min-h-[32px]",
+                          typeInfo?.color,
+                        )}
+                      >
+                        <span aria-hidden>{typeInfo?.icon}</span>
+                        <span>{typeInfo?.label}</span>
+                        <ChevronDown className="w-3 h-3 opacity-60" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="min-w-[140px]">
+                      {SECTION_TYPES.map((t) => (
+                        <DropdownMenuItem
+                          key={t.value}
+                          onClick={() => changeSectionType(section.id, t.value)}
+                          className={cn("text-xs", section.type === t.value && "bg-primary/10")}
+                        >
+                          <span className="mr-2">{t.icon}</span>
+                          {t.label}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+
+                  <div className="flex items-center gap-0.5">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Переместить вверх"
+                      disabled={index === 0}
+                      className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-primary disabled:opacity-30"
+                      onClick={() => moveSection(section.id, "up")}
+                    >
+                      <ChevronUp className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Переместить вниз"
+                      disabled={index === sections.length - 1}
+                      className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-primary disabled:opacity-30"
+                      onClick={() => moveSection(section.id, "down")}
+                    >
+                      <ChevronDown className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Добавить строку"
+                      className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-primary"
+                      onClick={() => updateSectionContent(section.id, section.content ? section.content + "\n" : "")}
+                    >
+                      <CornerDownLeft className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Очистить секцию"
+                      disabled={!section.content}
+                      className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+                      onClick={() => updateSectionContent(section.id, "")}
+                    >
+                      <Eraser className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Удалить секцию"
+                      className="h-9 w-9 min-h-[44px] min-w-[44px] text-muted-foreground hover:text-destructive"
+                      onClick={() => deleteSection(section.id)}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Content */}
+                <Textarea
+                  ref={(el) => {
+                    sectionRefs.current[section.id] = el;
+                  }}
+                  value={section.content}
+                  onChange={(e) => updateSectionContent(section.id, e.target.value)}
+                  placeholder="Текст секции — каждая строка с новой строки..."
+                  rows={3}
+                  data-section-id={section.id}
+                  className="border-0 rounded-none bg-transparent text-sm leading-relaxed resize-none focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/60"
+                />
+                <div className="flex items-center justify-between px-2 py-1 text-[10px] text-muted-foreground/70 bg-muted/10 border-t border-border/30">
+                  <span>
+                    {section.content.split("\n").filter((l) => l.trim()).length} стр · {section.content.length} симв
+                  </span>
+                </div>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
       </div>
 
       {/* Actions */}
@@ -426,8 +513,8 @@ export function LyricsVisualEditorCompact({ value, onChange, onAIGenerate }: Lyr
           {/* Add section */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="h-7 px-2 text-xs gap-1">
-                <Plus className="w-3 h-3" />
+              <Button variant="outline" size="sm" className="h-9 min-h-[44px] px-2.5 text-xs gap-1">
+                <Plus className="w-3.5 h-3.5" />
                 Секция
               </Button>
             </DropdownMenuTrigger>
@@ -452,14 +539,14 @@ export function LyricsVisualEditorCompact({ value, onChange, onAIGenerate }: Lyr
           </DropdownMenu>
 
           {/* AI Generate */}
-          {onAIGenerate && (
+          {onAIGenerate && sections.length > 0 && (
             <Button
               variant="outline"
               size="sm"
-              className="h-7 px-2 text-xs gap-1 text-primary hover:text-primary"
+              className="h-9 min-h-[44px] px-2.5 text-xs gap-1 text-primary hover:text-primary"
               onClick={onAIGenerate}
             >
-              <Sparkles className="w-3 h-3" />
+              <Sparkles className="w-3.5 h-3.5" />
               AI
             </Button>
           )}

--- a/src/components/generate-form/LyricsVisualEditorCompact.tsx
+++ b/src/components/generate-form/LyricsVisualEditorCompact.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Trash2, Sparkles, ChevronDown, ChevronUp, Eraser, CornerDownLeft, Wand2, PenLine } from "@/lib/icons";
+import { Plus, Trash2, Sparkles, ChevronDown, ChevronUp, Eraser, CornerDownLeft, Wand2 } from "@/lib/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/components/home/AiSuggestions.tsx
+++ b/src/components/home/AiSuggestions.tsx
@@ -1,5 +1,7 @@
 import { Sparkles } from "@/lib/icons";
 import { cn } from "@/lib/utils";
+import { motion, type Variants } from "@/lib/motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 interface Suggestion {
   icon: string;
@@ -25,28 +27,49 @@ const defaultSuggestions: Suggestion[] = [
   },
 ];
 
+const listVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+};
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 14 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.16, 1, 0.3, 1] } },
+};
+
 export function AiSuggestions({ onCreateClick, className }: AiSuggestionsProps) {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
     <div className={cn("space-y-3", className)}>
       <div className="flex items-center gap-2">
         <Sparkles className="w-4 h-4 text-primary" />
         <h3 className="font-sans font-bold text-[17px] text-foreground">AI предлагает</h3>
       </div>
-      <div className="flex flex-col gap-3">
+      <motion.div
+        className="flex flex-col gap-3"
+        initial={prefersReducedMotion ? undefined : "hidden"}
+        whileInView={prefersReducedMotion ? undefined : "visible"}
+        viewport={{ once: true, amount: 0.3 }}
+        variants={prefersReducedMotion ? undefined : listVariants}
+      >
         {defaultSuggestions.map((sg) => (
-          <button
+          <motion.button
             key={sg.title}
             onClick={onCreateClick}
-            className="p-4 rounded-2xl bg-gradient-to-br from-card to-card/80 border border-border hover:border-primary/30 transition-colors text-left"
+            variants={prefersReducedMotion ? undefined : itemVariants}
+            whileHover={prefersReducedMotion ? undefined : { y: -3 }}
+            whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
+            className="p-4 rounded-2xl bg-gradient-to-br from-card to-card/80 border border-border hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-[border-color,box-shadow] text-left"
           >
             <div className="flex items-center gap-2">
               <span className="text-lg">{sg.icon}</span>
               <p className="font-semibold text-[14.5px] text-foreground/90">{sg.title}</p>
             </div>
             <p className="text-[13px] text-muted-foreground mt-2 leading-relaxed">{sg.description}</p>
-          </button>
+          </motion.button>
         ))}
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/home/CommunityTrending.tsx
+++ b/src/components/home/CommunityTrending.tsx
@@ -1,6 +1,8 @@
-import { Play, Music2 } from "@/lib/icons";
+import { Play, Music2, Flame } from "@/lib/icons";
 import { LazyImage } from "@/components/ui/lazy-image";
 import { cn } from "@/lib/utils";
+import { motion, type Variants } from "@/lib/motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 /**
  * Minimal shape — accepts both Track and PublicTrackWithCreator so the
@@ -26,44 +28,85 @@ function formatPlayCount(count: number): string {
   return String(count);
 }
 
+const listVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.07, delayChildren: 0.05 } },
+};
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, x: -14 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.4, ease: [0.16, 1, 0.3, 1] } },
+};
+
 export function CommunityTrending({ tracks, onTrackClick, className }: CommunityTrendingProps) {
+  const prefersReducedMotion = useReducedMotion();
   if (!tracks || tracks.length === 0) return null;
 
   return (
     <div className={cn("space-y-3", className)}>
-      <h3 className="font-sans font-bold text-base text-foreground">В тренде сообщества</h3>
-      <div className="flex flex-col gap-1">
-        {tracks.slice(0, 4).map((track) => (
-          <button
-            key={track.id}
-            onClick={() => onTrackClick(track)}
-            className="flex items-center gap-3.5 p-2.5 rounded-xl hover:bg-card/60 transition-colors text-left w-full min-h-touch"
-          >
-            <div className="relative w-12 h-12 rounded-xl overflow-hidden flex-shrink-0">
-              <LazyImage
-                src={track.cover_url ?? ""}
-                alt={track.title ?? "Track"}
-                coverSize="small"
-                className="w-full h-full object-cover"
-                fallback={
-                  <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
-                    <Music2 className="w-5 h-5 text-primary/40" aria-hidden="true" />
-                  </div>
-                }
-              />
-              <div className="absolute inset-0 bg-gradient-radial from-foreground/20 to-transparent opacity-60 pointer-events-none" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="font-semibold text-sm text-foreground/90 truncate">{track.title ?? "Без названия"}</p>
-              <p className="text-xs text-muted-foreground mt-1 truncate">AI · {track.style ?? ""}</p>
-            </div>
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Play className="w-3.5 h-3.5 fill-primary text-primary" />
-              {formatPlayCount(track.play_count ?? 0)}
-            </div>
-          </button>
-        ))}
-      </div>
+      <h3 className="flex items-center gap-1.5 font-sans font-bold text-base text-foreground">
+        <Flame className="w-4 h-4 text-orange-400" aria-hidden="true" />В тренде сообщества
+      </h3>
+      <motion.div
+        className="flex flex-col gap-1"
+        initial={prefersReducedMotion ? undefined : "hidden"}
+        whileInView={prefersReducedMotion ? undefined : "visible"}
+        viewport={{ once: true, amount: 0.3 }}
+        variants={prefersReducedMotion ? undefined : listVariants}
+      >
+        {tracks.slice(0, 4).map((track, index) => {
+          const isTop = index === 0;
+          return (
+            <motion.button
+              key={track.id}
+              onClick={() => onTrackClick(track)}
+              variants={prefersReducedMotion ? undefined : itemVariants}
+              whileHover={prefersReducedMotion ? undefined : { x: 2 }}
+              whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
+              className={cn(
+                "group relative flex items-center gap-3.5 p-2.5 rounded-xl text-left w-full min-h-touch",
+                "border border-transparent transition-colors duration-200",
+                "hover:bg-card/60 hover:border-border/40",
+                isTop && "bg-gradient-to-r from-primary/[0.06] to-transparent",
+              )}
+            >
+              <div className="relative w-12 h-12 rounded-xl overflow-hidden flex-shrink-0">
+                <LazyImage
+                  src={track.cover_url ?? ""}
+                  alt={track.title ?? "Track"}
+                  coverSize="small"
+                  className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  fallback={
+                    <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+                      <Music2 className="w-5 h-5 text-primary/40" aria-hidden="true" />
+                    </div>
+                  }
+                />
+                <div className="absolute inset-0 bg-gradient-radial from-foreground/20 to-transparent opacity-60 pointer-events-none" />
+                {/* Rank badge */}
+                <span
+                  className={cn(
+                    "absolute -top-1 -left-1 flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold shadow-sm ring-2 ring-background",
+                    isTop
+                      ? "bg-gradient-to-br from-orange-400 to-primary text-white animate-pulse-glow"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {index + 1}
+                </span>
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-semibold text-sm text-foreground/90 truncate">{track.title ?? "Без названия"}</p>
+                <p className="text-xs text-muted-foreground mt-1 truncate">AI · {track.style ?? ""}</p>
+              </div>
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0">
+                <Play className="w-3.5 h-3.5 fill-primary text-primary transition-transform duration-200 group-hover:scale-110" />
+                {formatPlayCount(track.play_count ?? 0)}
+              </div>
+            </motion.button>
+          );
+        })}
+      </motion.div>
     </div>
   );
 }

--- a/src/components/home/DiscoverTabs.tsx
+++ b/src/components/home/DiscoverTabs.tsx
@@ -15,7 +15,19 @@ import { Button } from "@/components/ui/button";
 import { Loader2, TrendingUp, Sparkles, Clock } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { motion, type Variants } from "@/lib/motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import type { TrackData } from "@/components/track/track-card-new/types";
+
+const gridVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.035 } },
+};
+
+const cardVariants: Variants = {
+  hidden: { opacity: 0, y: 18, scale: 0.96 },
+  visible: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.32, ease: [0.16, 1, 0.3, 1] } },
+};
 
 interface DiscoverTabsProps {
   popularTracks: TrackData[];
@@ -47,39 +59,40 @@ const Grid = memo(function Grid({
   onTrackClick?: (track: TrackData) => void;
   onRemix?: (id: string) => void;
 }) {
+  const prefersReducedMotion = useReducedMotion();
+
   if (!tracks.length) {
-    return (
-      <p className="text-sm text-muted-foreground text-center py-8">Пока ничего нет</p>
-    );
+    return <p className="text-sm text-muted-foreground text-center py-8">Пока ничего нет</p>;
   }
   return (
-    <div
+    <motion.div
       className="grid gap-3 sm:gap-4"
       style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+      initial={prefersReducedMotion ? undefined : "hidden"}
+      animate={prefersReducedMotion ? undefined : "visible"}
+      variants={prefersReducedMotion ? undefined : gridVariants}
     >
       {tracks.map((track) => (
-        <UnifiedTrackCard
+        <motion.div
           key={track.id}
-          track={track}
-          variant="grid"
-          onPlay={() => onTrackClick?.(track)}
-          showActions={false}
-          data-onremix={onRemix ? "true" : undefined}
-        />
+          variants={prefersReducedMotion ? undefined : cardVariants}
+          whileHover={prefersReducedMotion ? undefined : { y: -3 }}
+          whileTap={prefersReducedMotion ? undefined : { scale: 0.97 }}
+        >
+          <UnifiedTrackCard
+            track={track}
+            variant="grid"
+            onPlay={() => onTrackClick?.(track)}
+            showActions={false}
+            data-onremix={onRemix ? "true" : undefined}
+          />
+        </motion.div>
       ))}
-    </div>
+    </motion.div>
   );
 });
 
-const LoadMore = ({
-  visible,
-  loading,
-  onClick,
-}: {
-  visible?: boolean;
-  loading?: boolean;
-  onClick?: () => void;
-}) => {
+const LoadMore = ({ visible, loading, onClick }: { visible?: boolean; loading?: boolean; onClick?: () => void }) => {
   if (!visible || !onClick) return null;
   return (
     <div className="flex justify-center pt-4">
@@ -114,11 +127,7 @@ export const DiscoverTabs = memo(function DiscoverTabs({
   const columns = isMobile ? 2 : 4;
 
   return (
-    <Tabs
-      value={tab}
-      onValueChange={(v) => setTab(v as "popular" | "new")}
-      className="w-full space-y-4"
-    >
+    <Tabs value={tab} onValueChange={(v) => setTab(v as "popular" | "new")} className="w-full space-y-4">
       <TabsList className="w-full sm:w-auto grid grid-cols-2 sm:inline-grid sm:grid-cols-2 h-9">
         <TabsTrigger value="popular" className="text-xs sm:text-sm gap-1.5">
           <TrendingUp className="h-3.5 w-3.5" />

--- a/src/components/home/HomeQuickCreate.tsx
+++ b/src/components/home/HomeQuickCreate.tsx
@@ -8,7 +8,7 @@
  */
 
 import { memo, useCallback, useState } from "react";
-import { motion } from "@/lib/motion";
+import { motion, AnimatePresence } from "@/lib/motion";
 import { Sparkles, Plus, Music2, Mic2, Guitar, Wand2 } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 import { useTelegram } from "@/contexts/TelegramContext";
@@ -119,14 +119,43 @@ export const HomeQuickCreate = memo(function HomeQuickCreate({ onCreateClick, cl
         </div>
 
         {/* Expanded options */}
-        {isExpanded && (
-          <div className="mt-3 lg:mt-4 grid grid-cols-2 lg:grid-cols-4 gap-2 lg:gap-3">
-            <QuickCreateOption Icon={Music2} label="Трек" description="Полный трек" onClick={handleCreate} />
-            <QuickCreateOption Icon={Guitar} label="Рифф" description="Инструментал" onClick={handleCreate} />
-            <QuickCreateOption Icon={Mic2} label="Кавер" description="Переделка" onClick={handleCreate} />
-            <QuickCreateOption Icon={Wand2} label="Ремикс" description="Новый звук" onClick={handleCreate} />
-          </div>
-        )}
+        <AnimatePresence initial={false}>
+          {isExpanded && (
+            <motion.div
+              initial={reducedMotion ? undefined : { height: 0, opacity: 0 }}
+              animate={reducedMotion ? undefined : { height: "auto", opacity: 1 }}
+              exit={reducedMotion ? undefined : { height: 0, opacity: 0 }}
+              transition={{
+                height: { duration: 0.25, ease: [0.16, 1, 0.3, 1] },
+                opacity: { duration: 0.2 },
+              }}
+              className="overflow-hidden"
+            >
+              <div className="mt-3 lg:mt-4 grid grid-cols-2 lg:grid-cols-4 gap-2 lg:gap-3">
+                {[
+                  { Icon: Music2, label: "Трек", description: "Полный трек" },
+                  { Icon: Guitar, label: "Рифф", description: "Инструментал" },
+                  { Icon: Mic2, label: "Кавер", description: "Переделка" },
+                  { Icon: Wand2, label: "Ремикс", description: "Новый звук" },
+                ].map((opt, i) => (
+                  <motion.div
+                    key={opt.label}
+                    initial={reducedMotion ? undefined : { opacity: 0, y: 8 }}
+                    animate={reducedMotion ? undefined : { opacity: 1, y: 0 }}
+                    transition={{ delay: reducedMotion ? 0 : 0.08 + i * 0.04, duration: 0.25 }}
+                  >
+                    <QuickCreateOption
+                      Icon={opt.Icon}
+                      label={opt.label}
+                      description={opt.description}
+                      onClick={handleCreate}
+                    />
+                  </motion.div>
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </section>
   );

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -15,7 +15,9 @@
  * Do not introduce additional spacing scales in home/* — extend this file.
  */
 
-import { forwardRef, type ReactNode, type ElementType } from "react";
+import { forwardRef, useMemo, type ReactNode, type ElementType } from "react";
+import { motion } from "@/lib/motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { cn } from "@/lib/utils";
 
 export type SectionDensity = "compact" | "comfortable" | "spacious" | "auto" | "4xl" | "5xl";
@@ -124,9 +126,14 @@ export const Section = forwardRef<HTMLElement, SectionProps>(function Section(
   const Tag = (as ?? "section") as ElementType;
   const hasHeader = Boolean(title || eyebrow || headerRight);
   const hasSurface = tone !== "plain";
+  const prefersReducedMotion = useReducedMotion();
+
+  // Scroll-reveal wrapper — memoized per tag so repeated renders don't
+  // recreate the component type (which would force a DOM remount).
+  const MotionTag = useMemo(() => motion(Tag as never), [Tag]);
 
   return (
-    <Tag
+    <MotionTag
       ref={ref as never}
       id={sectionId ? `section-${sectionId}` : undefined}
       data-section-id={sectionId}
@@ -140,9 +147,19 @@ export const Section = forwardRef<HTMLElement, SectionProps>(function Section(
         hasSurface && densityToInnerPad[density],
         className,
       )}
+      initial={prefersReducedMotion ? undefined : { opacity: 0, y: 28 }}
+      whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2, margin: "0px 0px -72px 0px" }}
+      transition={{ duration: 0.55, ease: [0.16, 1, 0.3, 1] }}
     >
       {hasHeader && (
-        <header className={cn("flex items-end justify-between gap-3", densityToHeaderGap[density])}>
+        <motion.header
+          className={cn("flex items-end justify-between gap-3", densityToHeaderGap[density])}
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
+          whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ duration: 0.4, delay: 0.05, ease: [0.16, 1, 0.3, 1] }}
+        >
           <div className="min-w-0 space-y-1">
             {eyebrow && (
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{eyebrow}</p>
@@ -151,10 +168,18 @@ export const Section = forwardRef<HTMLElement, SectionProps>(function Section(
             {subtitle && <p className="text-xs sm:text-sm text-muted-foreground">{subtitle}</p>}
           </div>
           {headerRight && <div className="shrink-0">{headerRight}</div>}
-        </header>
+        </motion.header>
       )}
-      <div className={cn(densityToBodyGap[density], bodyClassName)}>{children}</div>
-    </Tag>
+      <motion.div
+        className={cn(densityToBodyGap[density], bodyClassName)}
+        initial={prefersReducedMotion ? undefined : { opacity: 0, y: 12 }}
+        whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.15 }}
+        transition={{ duration: 0.45, delay: hasHeader ? 0.1 : 0.05, ease: [0.16, 1, 0.3, 1] }}
+      >
+        {children}
+      </motion.div>
+    </MotionTag>
   );
 });
 


### PR DESCRIPTION
Section (the shared wrapper for every Home cluster) now reveals on scroll via
whileInView, so Create/Trending/Discover/AI blocks fade and slide up as the
user scrolls instead of appearing instantly. Adds staggered entrance,
hover/press feedback and a ranked glow badge to CommunityTrending, staggered
card entrance to DiscoverTabs' track grid, an animated height/opacity expand
for HomeQuickCreate's preset options, and stagger plus press feedback for
AiSuggestions. All respect prefers-reduced-motion via useReducedMotion.

BottomNavigation gets a CSS/transform-only polish pass (per explicit choice
to avoid framer-motion there): bounce-eased active-tab pill, icon/label lift
on activation, and a permanent ambient glow-primary breathing halo on the FAB.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W6mgbSnKXXAW1bjSudhzqi