### PR TITLE
feat: redesign mobile track cards, reconnect homepage sections

### DIFF
--- a/src/components/track/QuickQueueButton.tsx
+++ b/src/components/track/QuickQueueButton.tsx
@@ -1,0 +1,72 @@
+/**
+ * QuickQueueButton - One-tap "add to queue" button for track cards
+ * Mirrors QuickLikeButton's sizing/variant contract so both can share
+ * the same cover-overlay action bar.
+ */
+
+import { memo, useCallback } from "react";
+import { ListEnd } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+import { useTelegram } from "@/contexts/TelegramContext";
+import { usePlaybackQueue } from "@/hooks/audio/usePlaybackQueue";
+import { toast } from "sonner";
+import { pill } from "@/lib/overlay-colors";
+import type { Track } from "@/types/track";
+
+interface QuickQueueButtonProps {
+  track: Track;
+  size?: "sm" | "md" | "lg";
+  variant?: "default" | "overlay" | "minimal";
+  className?: string;
+}
+
+export const QuickQueueButton = memo(function QuickQueueButton({
+  track,
+  size = "md",
+  variant = "default",
+  className,
+}: QuickQueueButtonProps) {
+  const { hapticFeedback } = useTelegram();
+  const { addTrack } = usePlaybackQueue();
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      hapticFeedback("light");
+      addTrack(track, false);
+      toast.success("Добавлено в очередь", { description: track.title });
+    },
+    [hapticFeedback, addTrack, track],
+  );
+
+  const sizeClasses = {
+    sm: "w-7 h-7 min-w-[44px] min-h-[44px]",
+    md: "w-9 h-9 min-w-[44px] min-h-[44px]",
+    lg: "w-11 h-11",
+  };
+
+  const iconSizes = {
+    sm: "w-3.5 h-3.5",
+    md: "w-4 h-4",
+    lg: "w-5 h-5",
+  };
+
+  const variantClasses = {
+    default: "rounded-lg transition-all active:scale-90 bg-muted/60 text-muted-foreground hover:bg-muted",
+    overlay: cn("rounded-full transition-all active:scale-90", pill.glassDark, "text-white/90 hover:text-white"),
+    minimal: "rounded-full transition-all active:scale-90 text-muted-foreground hover:text-foreground",
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn("flex items-center justify-center", sizeClasses[size], variantClasses[variant], className)}
+      aria-label="Добавить в очередь"
+    >
+      <ListEnd className={iconSizes[size]} />
+    </button>
+  );
+});

--- a/src/components/track/track-card-new/components/CardCoverActionBar.tsx
+++ b/src/components/track/track-card-new/components/CardCoverActionBar.tsx
@@ -1,0 +1,33 @@
+/**
+ * CardCoverActionBar - Layout atom for icon buttons placed on top of a cover image
+ *
+ * Purely presentational: positions its children in a row over a cover image.
+ * Visibility (hover-only vs always-visible) is the caller's responsibility.
+ */
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface CardCoverActionBarProps {
+  position: "top" | "bottom";
+  align?: "left" | "right" | "between";
+  className?: string;
+  children: ReactNode;
+}
+
+export function CardCoverActionBar({ position, align = "between", className, children }: CardCoverActionBarProps) {
+  return (
+    <div
+      className={cn(
+        "absolute left-2 right-2 flex items-center gap-1.5 z-10",
+        position === "top" ? "top-2" : "bottom-2",
+        align === "left" && "justify-start",
+        align === "right" && "justify-end",
+        align === "between" && "justify-between",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/track/track-card-new/components/CardFollowButton.tsx
+++ b/src/components/track/track-card-new/components/CardFollowButton.tsx
@@ -1,0 +1,66 @@
+/**
+ * CardFollowButton - Reusable "follow author" icon button for track cards
+ *
+ * Extracted from EnhancedVariant so Grid/Enhanced/Compact variants share
+ * one follow-button implementation instead of duplicating useFollow wiring.
+ */
+
+import { memo, useCallback } from "react";
+import { UserPlus } from "@/lib/icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
+import { useFollow } from "@/hooks/social/useFollow";
+import { useTelegram } from "@/contexts/TelegramContext";
+import { pill } from "@/lib/overlay-colors";
+
+interface CardFollowButtonProps {
+  userId: string;
+  isOwnTrack: boolean;
+  show?: boolean;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export const CardFollowButton = memo(function CardFollowButton({
+  userId,
+  isOwnTrack,
+  show = true,
+  size = "md",
+  className,
+}: CardFollowButtonProps) {
+  const { user } = useAuth();
+  const { hapticFeedback } = useTelegram();
+  const { isFollowing, isLoading, toggleFollow } = useFollow(userId);
+
+  const handleFollow = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      hapticFeedback("light");
+      toggleFollow();
+    },
+    [hapticFeedback, toggleFollow],
+  );
+
+  if (!user || !show || isOwnTrack || isFollowing) return null;
+
+  return (
+    <Button
+      size="icon"
+      variant="secondary"
+      className={cn(
+        size === "md"
+          ? "h-11 w-11 min-w-[44px] min-h-[44px] sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0"
+          : "h-9 w-9 min-w-[44px] min-h-[44px]",
+        "rounded-full border-0",
+        pill.glassDark,
+        className,
+      )}
+      onClick={handleFollow}
+      disabled={isLoading}
+      aria-label="Подписаться на автора"
+    >
+      <UserPlus className={size === "md" ? "w-5 h-5 sm:w-3.5 sm:h-3.5" : "w-4 h-4"} />
+    </Button>
+  );
+});

--- a/src/components/track/track-card-new/components/index.ts
+++ b/src/components/track/track-card-new/components/index.ts
@@ -6,3 +6,5 @@ export { PlayingIndicator } from "./PlayingIndicator";
 export { StatusIcon, StatusIcons } from "./StatusIcons";
 export { VersionPills } from "./VersionPills";
 export { TrackCoverImage } from "./TrackCoverImage";
+export { CardCoverActionBar } from "./CardCoverActionBar";
+export { CardFollowButton } from "./CardFollowButton";

--- a/src/components/track/track-card-new/types.ts
+++ b/src/components/track/track-card-new/types.ts
@@ -88,6 +88,9 @@ export interface StandardTrackCardProps extends BaseTrackCardProps {
   /** Whether to show action menu */
   showActions?: boolean;
 
+  /** Whether to show the "follow author" button (only relevant for public tracks by other users) */
+  showFollowButton?: boolean;
+
   /** Is first swipeable item (for onboarding) */
   isFirstSwipeableItem?: boolean;
 }

--- a/src/components/track/track-card-new/variants/CompactVariant.tsx
+++ b/src/components/track/track-card-new/variants/CompactVariant.tsx
@@ -15,8 +15,11 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/player-utils";
 import { UnifiedTrackSheet } from "@/components/track-actions";
+import { QuickLikeButton } from "@/components/track/QuickLikeButton";
+import { QuickQueueButton } from "@/components/track/QuickQueueButton";
 import { useTrackCardState } from "../hooks/useTrackCardState";
 import { TrackCoverImage } from "../components/TrackCoverImage";
+import { CardFollowButton } from "../components/CardFollowButton";
 import type { StandardTrackCardProps } from "../types";
 import type { Track } from "@/types/track";
 
@@ -29,6 +32,7 @@ export const CompactVariant = memo(function CompactVariant({
   index = 0,
   className,
   showActions = true,
+  showFollowButton = true,
 }: StandardTrackCardProps) {
   const {
     sheetOpen,
@@ -41,6 +45,7 @@ export const CompactVariant = memo(function CompactVariant({
     handleMouseEnter,
     handleMouseLeave,
     openSheet,
+    isOwnTrack,
   } = useTrackCardState({ track, onPlay, isPlaying: isPlayingProp });
 
   return (
@@ -88,20 +93,33 @@ export const CompactVariant = memo(function CompactVariant({
             </div>
           </div>
 
-          {showActions && (
-            <Button
-              size="icon"
-              variant="ghost"
-              className="w-11 h-11 min-w-[44px] min-h-[44px] rounded-full opacity-60 sm:opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 hover:bg-foreground/[0.06]"
-              onClick={(e) => {
-                e.stopPropagation();
-                openSheet();
-              }}
-              aria-label="Открыть меню трека"
-            >
-              <MoreHorizontal className="w-5 h-5" />
-            </Button>
-          )}
+          <div className="flex items-center gap-0.5 flex-shrink-0">
+            <QuickLikeButton
+              trackId={track.id}
+              isLiked={(track as Track & { user_liked?: boolean }).is_liked}
+              size="sm"
+              variant="minimal"
+            />
+            <QuickQueueButton track={track as unknown as Track} size="sm" variant="minimal" />
+            {!isOwnTrack && (
+              <CardFollowButton userId={track.user_id} isOwnTrack={isOwnTrack} show={showFollowButton} size="sm" />
+            )}
+
+            {showActions && (
+              <Button
+                size="icon"
+                variant="ghost"
+                className="w-11 h-11 min-w-[44px] min-h-[44px] rounded-full opacity-60 sm:opacity-0 group-hover:opacity-100 transition-opacity hover:bg-foreground/[0.06]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openSheet();
+                }}
+                aria-label="Открыть меню трека"
+              >
+                <MoreHorizontal className="w-5 h-5" />
+              </Button>
+            )}
+          </div>
         </div>
       </motion.div>
 

--- a/src/components/track/track-card-new/variants/EnhancedVariant.tsx
+++ b/src/components/track/track-card-new/variants/EnhancedVariant.tsx
@@ -5,13 +5,13 @@
  * - DoubleTapLike
  * - Creator info
  * - Follow button
- * - Add to playlist
+ * - Add to queue
  * - Share
  */
 
 import { memo, useState, useCallback } from "react";
 import { motion } from "@/lib/motion";
-import { Play, Pause, Share2, Music2, Plus, UserPlus, Check } from "@/lib/icons";
+import { Play, Pause, Share2, Music2, Check } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 import { LazyImage } from "@/components/ui/lazy-image";
 import { Card } from "@/components/ui/card";
@@ -21,11 +21,13 @@ import { usePlayerStore } from "@/hooks/audio/usePlayerState";
 import { useTelegram } from "@/contexts/TelegramContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useFollow } from "@/hooks/social/useFollow";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { LikeButton } from "@/components/ui/like-button";
+import { QuickQueueButton } from "@/components/track/QuickQueueButton";
+import { CardFollowButton } from "../components/CardFollowButton";
 import { DoubleTapLike } from "@/components/engagement/DoubleTapLike";
 import { CreatorAvatar, CreatorLink } from "@/components/ui/creator-avatar";
 import { PublicTrackDetailSheet } from "@/components/home/PublicTrackDetailSheet";
-import { AddToPlaylistSheet } from "@/components/home/AddToPlaylistSheet";
 import type { EnhancedTrackCardProps } from "../types";
 import type { Track } from "@/types/track";
 import { pill } from "@/lib/overlay-colors";
@@ -33,9 +35,7 @@ import { pill } from "@/lib/overlay-colors";
 export const EnhancedVariant = memo(function EnhancedVariant({
   track,
   onRemix,
-  onFollow,
   onShare,
-  onAddToPlaylist,
   showFollowButton = true,
   compact = false,
   className,
@@ -43,13 +43,13 @@ export const EnhancedVariant = memo(function EnhancedVariant({
   const { activeTrack, isPlaying, playTrack, pauseTrack } = usePlayerStore();
   const { hapticFeedback } = useTelegram();
   const { user } = useAuth();
+  const isMobile = useIsMobile();
   const [imageError, setImageError] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const [playlistSheetOpen, setPlaylistSheetOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
   const isOwnTrack = user?.id === track.user_id;
-  const { isFollowing, toggleFollow, isLoading: isFollowLoading } = useFollow(track.user_id);
+  const { isFollowing } = useFollow(track.user_id);
 
   const isCurrentTrack = activeTrack?.id === track.id;
   const isCurrentlyPlaying = isCurrentTrack && isPlaying;
@@ -108,32 +108,6 @@ export const EnhancedVariant = memo(function EnhancedVariant({
       }
     },
     [track.id, track.title, onShare],
-  );
-
-  const handleAddToPlaylist = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      hapticFeedback("light");
-      if (onAddToPlaylist) {
-        onAddToPlaylist(track.id);
-      } else {
-        setPlaylistSheetOpen(true);
-      }
-    },
-    [hapticFeedback, onAddToPlaylist, track.id],
-  );
-
-  const handleFollow = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      hapticFeedback("light");
-      if (onFollow) {
-        onFollow(track.user_id);
-      } else {
-        toggleFollow();
-      }
-    },
-    [hapticFeedback, onFollow, track.user_id, toggleFollow],
   );
 
   // Cover URL priority
@@ -255,48 +229,21 @@ export const EnhancedVariant = memo(function EnhancedVariant({
                 />
               </div>
 
-              {/* Bottom Actions on Hover */}
+              {/* Bottom Actions - always visible on mobile (touch), hover-reveal on desktop */}
               <motion.div
                 className="absolute bottom-2 left-2 right-2 flex items-center gap-1.5"
-                initial={{ opacity: 0, y: 10 }}
+                initial={false}
                 animate={{
-                  opacity: isHovered ? 1 : 0,
-                  y: isHovered ? 0 : 10,
+                  opacity: isMobile || isHovered ? 1 : 0,
+                  y: isMobile || isHovered ? 0 : 10,
                 }}
                 transition={{ duration: 0.2 }}
               >
-                {/* Add to Playlist - 44px touch target */}
-                {user && (
-                  <Button
-                    size="icon"
-                    variant="secondary"
-                    className={cn(
-                      "h-11 w-11 min-w-[44px] min-h-[44px] sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0 rounded-full border-0",
-                      pill.glassDark,
-                    )}
-                    onClick={handleAddToPlaylist}
-                    aria-label="Добавить в плейлист"
-                  >
-                    <Plus className="w-5 h-5 sm:w-3.5 sm:h-3.5 text-foreground" />
-                  </Button>
-                )}
+                {/* Add to Queue - 44px touch target */}
+                {user && <QuickQueueButton track={trackForPlayer} size="md" variant="overlay" />}
 
                 {/* Follow Creator */}
-                {user && showFollowButton && !isOwnTrack && !isFollowing && (
-                  <Button
-                    size="icon"
-                    variant="secondary"
-                    className={cn(
-                      "h-11 w-11 min-w-[44px] min-h-[44px] sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0 rounded-full border-0",
-                      pill.glassDark,
-                    )}
-                    onClick={handleFollow}
-                    disabled={isFollowLoading}
-                    aria-label="Подписаться на автора"
-                  >
-                    <UserPlus className="w-5 h-5 sm:w-3.5 sm:h-3.5 text-foreground" />
-                  </Button>
-                )}
+                <CardFollowButton userId={track.user_id} isOwnTrack={isOwnTrack} show={showFollowButton} size="md" />
 
                 {/* Share */}
                 <Button
@@ -358,13 +305,6 @@ export const EnhancedVariant = memo(function EnhancedVariant({
       </DoubleTapLike>
 
       <PublicTrackDetailSheet open={detailsOpen} onOpenChange={setDetailsOpen} track={track} />
-
-      <AddToPlaylistSheet
-        open={playlistSheetOpen}
-        onOpenChange={setPlaylistSheetOpen}
-        trackId={track.id}
-        trackTitle={track.title || undefined}
-      />
     </>
   );
 });

--- a/src/components/track/track-card-new/variants/GridVariant.tsx
+++ b/src/components/track/track-card-new/variants/GridVariant.tsx
@@ -21,8 +21,12 @@ import { LazyImage } from "@/components/ui/lazy-image";
 import { PlayOverlay } from "@/components/library/shared";
 import { UnifiedTrackSheet } from "@/components/track-actions";
 import { QuickLikeButton } from "@/components/track/QuickLikeButton";
+import { QuickQueueButton } from "@/components/track/QuickQueueButton";
+import { UnifiedVersionSelector } from "@/components/shared/UnifiedVersionSelector";
 import { useTrackCardState } from "../hooks/useTrackCardState";
 import { SimplifiedTagsRow } from "./SimplifiedTagsRow";
+import { CardCoverActionBar } from "../components/CardCoverActionBar";
+import { CardFollowButton } from "../components/CardFollowButton";
 import type { StandardTrackCardProps } from "../types";
 import type { Track } from "@/types/track";
 import {
@@ -44,9 +48,11 @@ export const GridVariant = memo(function GridVariant({
   onToggleLike,
   onTagClick,
   stemCount = 0,
+  versionCount = 0,
   isPlaying: isPlayingProp,
   className,
   showActions = true,
+  showFollowButton = true,
 }: StandardTrackCardProps) {
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -180,11 +186,27 @@ export const GridVariant = memo(function GridVariant({
             {/* Play Overlay */}
             <PlayOverlay isPlaying={isCurrentlyPlaying} isMobile={isMobile} onPlay={handlePlay} />
 
-            {/* Stem badge - only when stems available */}
+            {/* Top action bar - Like / Queue / Follow, always visible on the cover */}
+            <CardCoverActionBar position="top" align="between">
+              <QuickLikeButton
+                trackId={track.id}
+                isLiked={(track as Track & { user_liked?: boolean }).is_liked}
+                size="sm"
+                variant="overlay"
+              />
+              <div className="flex items-center gap-1.5">
+                <QuickQueueButton track={track as unknown as Track} size="sm" variant="overlay" />
+                {!isOwnTrack && (
+                  <CardFollowButton userId={track.user_id} isOwnTrack={isOwnTrack} show={showFollowButton} size="sm" />
+                )}
+              </div>
+            </CardCoverActionBar>
+
+            {/* Stem badge - only when stems available, kept off the action row */}
             {stemCount > 0 && (
               <Badge
                 variant="secondary"
-                className="absolute top-2 right-2 text-overline px-1.5 py-0.5 bg-background/90 backdrop-blur-sm border-0 gap-1"
+                className="absolute bottom-2 left-2 text-overline px-1.5 py-0.5 bg-background/90 backdrop-blur-sm border-0 gap-1"
               >
                 <Layers className="w-3 h-3" />
                 {stemCount}
@@ -192,44 +214,34 @@ export const GridVariant = memo(function GridVariant({
             )}
           </div>
 
-          {/* Content - fixed height so tag length never changes card size */}
-          <div className="p-3 flex flex-col gap-1.5 h-[68px]">
+          {/* Content */}
+          <div className="p-3 flex flex-col gap-1.5 min-h-[84px]">
             <div className="flex items-start justify-between gap-1.5 sm:gap-2 min-h-0">
               <h3
-                className="font-semibold text-xs sm:text-sm xl:text-base 2xl:text-lg flex-1 min-w-0 leading-tight line-clamp-2 xs:line-clamp-1 break-words"
+                className="font-semibold text-xs sm:text-sm xl:text-base 2xl:text-lg flex-1 min-w-0 leading-tight line-clamp-2 break-words"
                 title={track.title || undefined}
               >
                 {track.title || "Без названия"}
               </h3>
 
-              <div className="flex items-center gap-0.5 flex-shrink-0 -mt-1">
-                {/* Quick Like */}
-                <QuickLikeButton
-                  trackId={track.id}
-                  isLiked={(track as Track & { user_liked?: boolean }).is_liked}
-                  size="sm"
-                  variant="minimal"
-                />
-
-                {/* More menu - visible on hover (desktop) or always (mobile) */}
-                {showActions && (
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className={cn(
-                      "w-9 h-9 min-w-[44px] min-h-[44px] flex-shrink-0 transition-opacity rounded-full",
-                      isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100",
-                    )}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openSheet();
-                    }}
-                    aria-label="Дополнительные действия"
-                  >
-                    <MoreHorizontal className="w-4 h-4" />
-                  </Button>
-                )}
-              </div>
+              {/* More menu - visible on hover (desktop) or always (mobile) */}
+              {showActions && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className={cn(
+                    "w-9 h-9 min-w-[44px] min-h-[44px] flex-shrink-0 -mt-1 transition-opacity rounded-full",
+                    isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+                  )}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openSheet();
+                  }}
+                  aria-label="Дополнительные действия"
+                >
+                  <MoreHorizontal className="w-4 h-4" />
+                </Button>
+              )}
             </div>
 
             {/* Tags - single row, capped width, never wraps */}
@@ -237,9 +249,19 @@ export const GridVariant = memo(function GridVariant({
               style={track.style}
               tags={track.tags}
               onClick={onTagClick}
-              maxTags={2}
+              maxTags={3}
               className="mt-auto"
             />
+
+            {/* Version switcher - only when multiple versions exist */}
+            {versionCount > 1 && (
+              <UnifiedVersionSelector
+                trackId={track.id}
+                variant="inline"
+                showLabels={false}
+                className="flex-shrink-0"
+              />
+            )}
           </div>
         </Card>
       </motion.div>

--- a/src/components/track/track-card-new/variants/ListVariant.tsx
+++ b/src/components/track/track-card-new/variants/ListVariant.tsx
@@ -26,6 +26,8 @@ import { MarqueeTitle } from "@/components/library/MarqueeTitle";
 import { SwipeableTrackItem } from "@/components/library/SwipeableTrackItem";
 import { UnifiedTipCard } from "@/components/hints";
 import { UnifiedTrackMenu, UnifiedTrackSheet } from "@/components/track-actions";
+import { usePlaybackQueue } from "@/hooks/audio/usePlaybackQueue";
+import { toast } from "sonner";
 import { useTrackCardState } from "../hooks/useTrackCardState";
 import type { StandardTrackCardProps } from "../types";
 import type { Track } from "@/types/track";
@@ -47,11 +49,14 @@ export const ListVariant = memo(function ListVariant({
 }: StandardTrackCardProps) {
   const { sheetOpen, setSheetOpen, isMobile, isCurrentlyPlaying, handlePlay, handleCardClick, openSheet, isOwnTrack } =
     useTrackCardState({ track, onPlay, isPlaying: isPlayingProp });
+  const { addTrack } = usePlaybackQueue();
 
   // Swipe action handlers
   const handleSwipeAddToQueue = useCallback(() => {
-    // Import addToQueue from store if needed
-  }, []);
+    triggerHapticFeedback("light");
+    addTrack(track as unknown as Track, false);
+    toast.success("Добавлено в очередь", { description: track.title || undefined });
+  }, [addTrack, track]);
 
   const handleSwipeSwitchVersion = useCallback(() => {
     if (versionCount <= 1 || !onVersionSwitch) return;

--- a/src/hooks/useHomePageData.ts
+++ b/src/hooks/useHomePageData.ts
@@ -89,6 +89,7 @@ export function useHomePageData(options: UseHomePageDataOptions = {}) {
     publicContent,
     recentTracks,
     popularTracks,
+    tracksByGenre: publicContent?.tracksByGenre ?? {},
 
     // Loading states
     isLoading,

--- a/src/index.css
+++ b/src/index.css
@@ -384,9 +384,6 @@ All colors MUST be HSL.
     /* Скрытие нативных скроллбаров на мобильных */
     -ms-overflow-style: none;
     scrollbar-width: none;
-    /* GPU acceleration hint for smooth scrolling */
-    -webkit-transform: translateZ(0);
-    transform: translateZ(0);
   }
 
   body::-webkit-scrollbar {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,7 +32,8 @@ import { ContinueDraftCard } from "@/components/home/ContinueDraftCard";
 import { CreativePresetsSection } from "@/components/home/CreativePresetsSection";
 import { DiscoverTabs } from "@/components/home/DiscoverTabs";
 import { YouStrip } from "@/components/home/YouStrip";
-import { CommunityTrending } from "@/components/home/CommunityTrending";
+import { FeaturedSection } from "@/components/home/FeaturedSection";
+import { GenreTabsSection } from "@/components/home/GenreTabsSection";
 import { AiSuggestions } from "@/components/home/AiSuggestions";
 import { Section, sectionTokens } from "@/components/layout/Section";
 
@@ -62,6 +63,7 @@ const Index = () => {
   const {
     recentTracks,
     popularTracks,
+    tracksByGenre,
     isLoading,
     hasMoreRecent,
     isLoadingMoreRecent,
@@ -129,7 +131,20 @@ const Index = () => {
 
   const trendingBlock = (
     <Section sectionId="trending" density="comfortable" tone="plain">
-      <CommunityTrending tracks={popularTracks} onTrackClick={handleTrackClick} />
+      <FeaturedSection
+        tracks={popularTracks}
+        isLoading={isLoading}
+        onTrackClick={handleTrackClick}
+        hasMore={hasMorePopular}
+        isLoadingMore={isLoadingMorePopular}
+        onLoadMore={fetchMorePopular}
+      />
+    </Section>
+  );
+
+  const genresBlock = (
+    <Section sectionId="genres" eyebrow="Жанры" title="По жанрам" density="comfortable">
+      <GenreTabsSection tracks={popularTracks} tracksByGenre={tracksByGenre} isLoading={isLoading} />
     </Section>
   );
 
@@ -183,6 +198,7 @@ const Index = () => {
               {heroBlock}
               {createBlock}
               {trendingBlock}
+              {genresBlock}
               {discoverBlock}
               {aiSuggestBlock}
             </div>


### PR DESCRIPTION
- GridVariant: move like/queue/follow above the cover, relax title/tag
  truncation, add missing A/B version switcher for Library grid view
- EnhancedVariant: make like/queue/follow/share always visible on touch
  (was hover-only, broken on mobile), extract shared follow-button logic
- CompactVariant: add like/queue/follow actions (Community list view)
- ListVariant: wire up the previously no-op swipe-to-queue gesture
- Add reusable CardCoverActionBar, CardFollowButton, QuickQueueButton
- Reconnect FeaturedSection (trending) and GenreTabsSection (by-genre
  browsing) on the homepage — both existed fully built but were
  disconnected from Index.tsx in a prior redesign
- Fix tooltip/popover positioning: remove transform: translateZ(0) from
  <body>, which made it the containing block for all Radix portal
  content and pinned fixed-position overlays to the bottom of the page

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XFWDTkhoxSJ3xdeigdSgPJ