### PR TITLE
fix(mobile): stop pull-to-refresh from blocking scroll, fix genre tabs flashing empty

### DIFF
--- a/src/components/home/GenreTabsSection.tsx
+++ b/src/components/home/GenreTabsSection.tsx
@@ -114,6 +114,7 @@ export function GenreTabsSection({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading: isActiveGenreLoading,
   } = useInfiniteGenreTracks({
     genre: activeGenre,
     pageSize: 20,
@@ -236,7 +237,7 @@ export function GenreTabsSection({
               iconColor={genre.color}
               iconGradient={genre.gradient}
               tracks={tracksByGenre[genre.id] || []}
-              isLoading={isLoading}
+              isLoading={isLoading || (genre.id === activeGenre && isActiveGenreLoading)}
               maxTracks={20}
               columns={2}
               showMoreLink={`/community?genre=${genre.id}`}

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -60,9 +60,31 @@ export function usePullToRefresh({
   useEffect(() => {
     if (!container || !enabled) return;
 
+    // `container` is just a layout wrapper — it has no overflow/scroll of its
+    // own, so its scrollTop is always 0. The page actually scrolls on the
+    // nearest scrollable ancestor (e.g. <main id="main-content"> in
+    // MainLayout). Checking container.scrollTop here always reads "at top",
+    // so preventDefault() below used to fire on every downward touchmove
+    // anywhere on the page, not just when genuinely scrolled to top —
+    // breaking native scrolling on mobile. Resolve the real scroll parent
+    // once and read its scrollTop instead.
+    const getScrollParent = (el: HTMLElement): HTMLElement => {
+      let node: HTMLElement | null = el.parentElement;
+      while (node && node !== document.body) {
+        const style = getComputedStyle(node);
+        if (/(auto|scroll)/.test(style.overflowY) && node.scrollHeight > node.clientHeight) {
+          return node;
+        }
+        node = node.parentElement;
+      }
+      return (document.scrollingElement as HTMLElement | null) || document.documentElement;
+    };
+
+    const scrollParent = getScrollParent(container);
+
     const handleTouchStart = (e: TouchEvent) => {
       // Only enable when scrolled to top
-      if (container.scrollTop > 0) return;
+      if (scrollParent.scrollTop > 0) return;
 
       startYRef.current = e.touches[0].clientY;
       isPullingRef.current = true;
@@ -71,7 +93,7 @@ export function usePullToRefresh({
 
     const handleTouchMove = (e: TouchEvent) => {
       // Use ref for immediate value check
-      if (!isPullingRef.current || container.scrollTop > 0) return;
+      if (!isPullingRef.current || scrollParent.scrollTop > 0) return;
 
       currentYRef.current = e.touches[0].clientY;
       const distance = Math.max(0, currentYRef.current - startYRef.current);


### PR DESCRIPTION
usePullToRefresh checked container.scrollTop on the wrapper div, which never
scrolls itself (the real scroll container is <main id="main-content"> several
levels up in MainLayout). Its scrollTop is always 0, so the "only pull when
at top" guard never engaged and touchmove preventDefault() fired on any
downward drag anywhere on the page, hijacking native scroll on mobile
(Home and Library both use this hook). Now resolves the actual scrollable
ancestor and reads its scrollTop instead.

GenreTabsSection passed the page-level batch isLoading flag into each genre
tab's TracksGridSection, ignoring useInfiniteGenreTracks' own fetch state for
the active tab. Once the batch query settled, isLoading was false even while
a freshly-selected genre tab was still fetching its first page, so
TracksGridSection's `return null` on empty tracks fired immediately and the
section appeared to vanish. Now combines both loading flags for the active
tab.