### PR TITLE
refactor: eliminate all 58 no-explicit-any lint errors, fix 2 bugs hidden by casts

### DIFF
--- a/src/api/lyrics.api.ts
+++ b/src/api/lyrics.api.ts
@@ -634,6 +634,9 @@ export async function invokeLyricsAssistant(body: {
   lyrics?: string;
   section?: string;
   style?: string;
+  structure?: string;
+  message?: string;
+  context?: Record<string, unknown>;
 }): Promise<{
   data: { lyrics?: string; suggestions?: string[]; error?: string } | null;
   error: Error | null;

--- a/src/components/stem-studio/UnifiedWaveformTimeline.tsx
+++ b/src/components/stem-studio/UnifiedWaveformTimeline.tsx
@@ -14,9 +14,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Skeleton } from "@/components/ui/skeleton";
 import { logger } from "@/lib/logger";
 
-type WaveSurferCtor = typeof import("wavesurfer.js");
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Wavesurfer.js instance type is not exposed as a named export
-type WaveSurferInstance = any;
+type WaveSurferModule = typeof import("wavesurfer.js");
+type WaveSurferInstance = InstanceType<WaveSurferModule["default"]>;
 
 interface UnifiedWaveformTimelineProps {
   audioUrl: string;
@@ -179,7 +178,7 @@ export const UnifiedWaveformTimeline = memo(
         try {
           const mod = await import("wavesurfer.js");
           // ESM/CJS interop: prefer default export when present
-          const WaveSurfer: any = (mod as any).default ?? mod;
+          const WaveSurfer = (mod.default ?? mod) as WaveSurferModule["default"];
           if (!mounted) return;
 
           const wavesurfer = WaveSurfer.create({
@@ -206,7 +205,7 @@ export const UnifiedWaveformTimeline = memo(
             setIsLoading(false);
           });
 
-          wavesurfer.on("error", (err: any) => {
+          wavesurfer.on("error", (err: Error) => {
             // Suppress AbortError as it's expected during cleanup
             if (err?.name === "AbortError" || err?.message?.includes("aborted")) {
               return;

--- a/src/components/studio/unified/MobileDAWTimeline.tsx
+++ b/src/components/studio/unified/MobileDAWTimeline.tsx
@@ -53,7 +53,7 @@ interface MobileDAWTimelineProps {
 // Track type colors with waveform color
 const TRACK_TYPE_CONFIG: Record<
   string,
-  { bg: string; border: string; waveColor: string; icon: React.ComponentType<any> }
+  { bg: string; border: string; waveColor: string; icon: React.ComponentType<{ className?: string }> }
 > = {
   main: { bg: "bg-primary/20", border: "border-primary", waveColor: "blue", icon: Music },
   vocal: { bg: "bg-pink-500/20", border: "border-pink-500", waveColor: "pink", icon: Mic2 },

--- a/src/components/studio/unified/NotationDrawer.tsx
+++ b/src/components/studio/unified/NotationDrawer.tsx
@@ -64,7 +64,8 @@ export const NotationDrawer = memo(function NotationDrawer({
   const safeAreaTop = `calc(max(var(--tg-content-safe-area-inset-top, 0px) + var(--tg-safe-area-inset-top, 0px) + 0.5rem, env(safe-area-inset-top, 0px) + 0.5rem))`;
   const safeAreaBottom = `calc(max(var(--tg-safe-area-inset-bottom, 0px) + 1rem, env(safe-area-inset-bottom, 0px) + 1rem))`;
 
-  const effectiveDuration = duration ?? (track as any)?.duration ?? track?.clips?.[0]?.duration ?? 60;
+  const effectiveDuration =
+    duration ?? (track as (StudioTrack & { duration?: number }) | null)?.duration ?? track?.clips?.[0]?.duration ?? 60;
 
   const availableFiles = useMemo(() => {
     if (!transcriptionData) return [];

--- a/src/components/studio/unified/StudioDialogs.tsx
+++ b/src/components/studio/unified/StudioDialogs.tsx
@@ -18,9 +18,10 @@ import { NotationDrawer } from "./NotationDrawer";
 import { ChordSheet } from "./ChordSheet";
 import { AddInstrumentalDrawer } from "./AddInstrumentalDrawer";
 import type { RecordingType } from "./RecordTrackDrawer";
-import type { StudioModalType } from "@/hooks/studio/useStudioModals";
+import type { UseStudioModalsResult } from "@/hooks/studio/useStudioModals";
 import type { StudioTrack } from "@/stores/studio/types";
 import type { Track } from "@/types/track";
+import type { Tables } from "@/integrations/supabase/types";
 
 /**
  * Track object passed to separation dialogs. Mirrors the minimal subset of
@@ -31,6 +32,13 @@ type SeparationTrack = Pick<Track, "id" | "title"> & {
   suno_id: string | null;
   suno_task_id: string | null;
 };
+
+/**
+ * Separation dialogs declare full DB-row / Track props but only read the
+ * SeparationTrack subset. Single documented widening instead of scattered
+ * `as any` casts at each call site.
+ */
+const asDialogTrack = (track: SeparationTrack) => track as unknown as Tables<"tracks"> & Track;
 
 interface StudioDialogsProps {
   id: string;
@@ -45,12 +53,7 @@ interface StudioDialogsProps {
   duration: number;
   isPlaying: boolean;
   isSeparating: boolean;
-  modals: {
-    isOpen: (type: StudioModalType) => boolean;
-    getOpenChangeHandler: (type: StudioModalType) => (open: boolean) => void;
-    close: () => void;
-    payload: { selectedTrack?: { transcription?: unknown; name?: string; chords?: unknown[] } | null };
-  };
+  modals: Pick<UseStudioModalsResult, "isOpen" | "getOpenChangeHandler" | "close" | "payload">;
   onStemSeparationConfirm: (mode: "simple" | "detailed") => Promise<void>;
   onRecordingComplete: (track: {
     id: string;
@@ -134,7 +137,7 @@ export const StudioDialogs = memo(function StudioDialogs({
         <ExtendDialog
           open={modals.isOpen("extend")}
           onOpenChange={modals.getOpenChangeHandler("extend")}
-          track={trackForSeparation as any}
+          track={asDialogTrack(trackForSeparation)}
         />
       )}
 
@@ -143,7 +146,7 @@ export const StudioDialogs = memo(function StudioDialogs({
         <RemixDialog
           open={modals.isOpen("remix")}
           onOpenChange={modals.getOpenChangeHandler("remix")}
-          track={trackForSeparation as any}
+          track={asDialogTrack(trackForSeparation)}
         />
       )}
 
@@ -152,7 +155,7 @@ export const StudioDialogs = memo(function StudioDialogs({
         <LazyAddVocalsDrawer
           open={modals.isOpen("addVocals")}
           onOpenChange={modals.getOpenChangeHandler("addVocals")}
-          track={trackForSeparation as any}
+          track={asDialogTrack(trackForSeparation)}
         />
       )}
 
@@ -168,8 +171,8 @@ export const StudioDialogs = memo(function StudioDialogs({
       <NotationDrawer
         open={modals.isOpen("notation")}
         onClose={modals.close}
-        track={(modals.payload.selectedTrack ?? null) as any}
-        transcriptionData={(modals.payload.selectedTrack as any)?.transcription}
+        track={modals.payload.selectedTrack ?? null}
+        transcriptionData={modals.payload.selectedTrack?.transcription}
         currentTime={currentTime}
         duration={duration}
         isPlaying={isPlaying}
@@ -181,7 +184,7 @@ export const StudioDialogs = memo(function StudioDialogs({
         open={modals.isOpen("chordSheet")}
         onClose={modals.close}
         trackName={modals.payload.selectedTrack?.name || "Track"}
-        chords={(modals.payload.selectedTrack?.chords || []) as any}
+        chords={modals.payload.selectedTrack?.chords ?? []}
         currentTime={currentTime}
         onSeekToChord={onSeek}
       />
@@ -191,7 +194,7 @@ export const StudioDialogs = memo(function StudioDialogs({
         <AddInstrumentalDrawer
           open={modals.isOpen("addInstrumental")}
           onOpenChange={modals.getOpenChangeHandler("addInstrumental")}
-          track={trackForSeparation as any}
+          track={asDialogTrack(trackForSeparation)}
         />
       )}
     </>

--- a/src/components/studio/unified/StudioNotationPanel.tsx
+++ b/src/components/studio/unified/StudioNotationPanel.tsx
@@ -67,7 +67,7 @@ export const StudioNotationPanel = memo(function StudioNotationPanel({
   const isMobile = useIsMobile();
   const [isDownloading, setIsDownloading] = useState<string | null>(null);
 
-  const durationSeconds = (track as any).duration ?? track.clips?.[0]?.duration ?? 60;
+  const durationSeconds = (track as StudioTrack & { duration?: number }).duration ?? track.clips?.[0]?.duration ?? 60;
 
   const {
     data: rawTranscription,

--- a/src/components/studio/unified/StudioTranscriptionPanel.tsx
+++ b/src/components/studio/unified/StudioTranscriptionPanel.tsx
@@ -16,7 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import type { StudioTrack } from "@/stores/useUnifiedStudioStore";
-import { useSaveTranscription } from "@/hooks/useStemTranscription";
+import { useSaveTranscription, type TranscriptionNote } from "@/hooks/useStemTranscription";
 import { useStudioTrackStems } from "@/hooks/studio/useStudioTrackStems";
 import { useLatestStemTranscription } from "@/hooks/studio/useLatestStemTranscription";
 import { useReplicateMidiTranscription } from "@/hooks/studio/useReplicateMidiTranscription";
@@ -191,7 +191,7 @@ export const StudioTranscriptionPanel = memo(function StudioTranscriptionPanel({
             trackId,
             midiUrl,
             model: "basic-pitch",
-            notes: (Array.isArray(data?.notes) ? data.notes : null) as any,
+            notes: (Array.isArray(data?.notes) ? data.notes : null) as TranscriptionNote[] | null,
             notesCount: typeof notesCount === "number" ? notesCount : null,
           });
         }
@@ -251,8 +251,7 @@ export const StudioTranscriptionPanel = memo(function StudioTranscriptionPanel({
       const normalized = {
         midiUrl: (data?.files?.midi || data?.files?.midi_url || data?.midi_url || null) as string | null,
         midiQuantUrl: (data?.files?.midi_quant || data?.files?.midi_quant_url || data?.midi_quant_url || null) as
-          | string
-          | null,
+          string | null,
         mxmlUrl: (data?.files?.mxml ||
           data?.files?.musicxml ||
           data?.files?.musicxml_url ||
@@ -299,7 +298,7 @@ export const StudioTranscriptionPanel = memo(function StudioTranscriptionPanel({
             pdfUrl: normalized.pdfUrl,
             gp5Url: normalized.gp5Url,
             model: `klangio:${klangioModel}`,
-            notes: (Array.isArray(data?.notes) ? data.notes : null) as any,
+            notes: (Array.isArray(data?.notes) ? data.notes : null) as TranscriptionNote[] | null,
             bpm: normalized.bpm,
             keyDetected: normalized.keyDetected,
             notesCount: normalized.notesCount,
@@ -371,17 +370,17 @@ export const StudioTranscriptionPanel = memo(function StudioTranscriptionPanel({
   }, []);
 
   // Merge existing transcription with new result
-  const displayResult: any =
+  const displayResult: TranscriptionResult | null =
     result ||
     (existingTranscription
       ? {
-          midi_url: existingTranscription.midi_url,
-          midi_quant_url: existingTranscription.midi_quant_url,
-          musicxml_url: existingTranscription.mxml_url,
-          pdf_url: existingTranscription.pdf_url,
-          gp5_url: existingTranscription.gp5_url,
-          bpm: existingTranscription.bpm,
-          key: existingTranscription.key_detected,
+          midi_url: existingTranscription.midi_url ?? undefined,
+          midi_quant_url: existingTranscription.midi_quant_url ?? undefined,
+          musicxml_url: existingTranscription.mxml_url ?? undefined,
+          pdf_url: existingTranscription.pdf_url ?? undefined,
+          gp5_url: existingTranscription.gp5_url ?? undefined,
+          bpm: existingTranscription.bpm ?? undefined,
+          key: existingTranscription.key_detected ?? undefined,
           notes_count:
             existingTranscription.notes_count ??
             (Array.isArray(existingTranscription.notes) ? existingTranscription.notes.length : undefined),

--- a/src/components/studio/unified/StudioWaveformTimeline.tsx
+++ b/src/components/studio/unified/StudioWaveformTimeline.tsx
@@ -33,31 +33,8 @@ interface StudioWaveformTimelineProps {
   onSectionClick?: (section: DetectedSection, index: number) => void;
 }
 
-// Dynamic import type for wavesurfer. The constructor and instance APIs we use
-// are a narrow subset of the wavesurfer public surface; the `unknown` callback
-// payload reflects the variable event shapes wavesurfer emits.
-interface WaveSurferStatic {
-  default?: WaveSurferStatic;
-  create: (options: {
-    container: HTMLElement;
-    height: number;
-    waveColor: string;
-    progressColor: string;
-    cursorColor: string;
-    cursorWidth: number;
-    barWidth: number;
-    barGap: number;
-    barRadius: number;
-    normalize: boolean;
-  }) => WaveSurferInstance;
-}
-type WaveSurferCtor = WaveSurferStatic | { create: WaveSurferStatic["create"]; default?: WaveSurferStatic };
-type WaveSurferInstance = {
-  on: (event: string, callback: (data?: unknown) => void) => void;
-  load: (url: string) => void;
-  destroy: () => void;
-  getDuration: () => number;
-};
+type WaveSurferModule = typeof import("wavesurfer.js");
+type WaveSurferInstance = InstanceType<WaveSurferModule["default"]>;
 
 export const StudioWaveformTimeline = memo(function StudioWaveformTimeline({
   audioUrl,
@@ -100,7 +77,7 @@ export const StudioWaveformTimeline = memo(function StudioWaveformTimeline({
 
       try {
         const mod = await import("wavesurfer.js");
-        const WaveSurfer: any = (mod as any).default ?? mod;
+        const WaveSurfer = (mod.default ?? mod) as WaveSurferModule["default"];
         if (!mounted) return;
 
         // Clean up previous instance
@@ -132,7 +109,7 @@ export const StudioWaveformTimeline = memo(function StudioWaveformTimeline({
           setIsLoading(false);
         });
 
-        wavesurfer.on("error", (err: any) => {
+        wavesurfer.on("error", (err: Error) => {
           if (err?.name === "AbortError" || err?.message?.includes("aborted")) {
             return;
           }

--- a/src/components/studio/unified/UnifiedMixerChannel.tsx
+++ b/src/components/studio/unified/UnifiedMixerChannel.tsx
@@ -21,7 +21,7 @@ export type ChannelVariant = "vertical" | "horizontal" | "compact";
 const STEM_CONFIG: Record<
   string,
   {
-    icon: React.ComponentType<any>;
+    icon: React.ComponentType<{ className?: string }>;
     label: string;
     color: string;
     shortLabel: string;

--- a/src/components/studio/unified/UnifiedStudioMobile.tsx
+++ b/src/components/studio/unified/UnifiedStudioMobile.tsx
@@ -106,7 +106,7 @@ export const UnifiedStudioMobile = memo(function UnifiedStudioMobile({
       isPlaying: studio.isPlaying,
     },
     trackForSeparation,
-    separate: separate as any,
+    separate,
   });
 
   // Convert to DAW format
@@ -245,7 +245,7 @@ export const UnifiedStudioMobile = memo(function UnifiedStudioMobile({
         duration={studio.duration}
         isPlaying={studio.isPlaying}
         isSeparating={isSeparating}
-        modals={modals as any}
+        modals={modals}
         onStemSeparationConfirm={handlers.handleStemSeparationConfirm}
         onRecordingComplete={handlers.handleRecordingComplete}
         onVersionSaved={handleVersionSaved}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import * as RechartsPrimitive from "recharts";
+import type { Payload as TooltipPayload } from "recharts/types/component/DefaultTooltipContent";
+import type { LegendPayload } from "recharts/types/component/DefaultLegendContent";
 
 import { cn } from "@/lib/utils";
 
@@ -89,7 +91,7 @@ ${colorConfig
 
 const ChartTooltip = RechartsPrimitive.Tooltip;
 
-type ChartTooltipPayloadItem = NonNullable<(RechartsPrimitive.TooltipProps<number, string> & { payload?: any[] })["payload"]>[number];
+type ChartTooltipPayloadItem = TooltipPayload<number, string>;
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
@@ -241,7 +243,7 @@ ChartTooltipContent.displayName = "ChartTooltip";
 
 const ChartLegend = RechartsPrimitive.Legend;
 
-type ChartLegendPayloadItem = NonNullable<(RechartsPrimitive.LegendProps & { payload?: any[] })["payload"]>[number];
+type ChartLegendPayloadItem = LegendPayload;
 
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,

--- a/src/hooks/audio-reference/useReferenceAudioAnalysis.ts
+++ b/src/hooks/audio-reference/useReferenceAudioAnalysis.ts
@@ -10,8 +10,8 @@ import { useMutation } from "@tanstack/react-query";
 import {
   analyzeReferenceAudio,
   type AnalyzeReferenceParams,
+  type ReferenceAnalysis,
 } from "@/services/audio-reference/reference-analysis.service";
-type ReferenceAnalysis = any;
 
 export function useReferenceAudioAnalysis() {
   const mutation = useMutation<ReferenceAnalysis | null, Error, AnalyzeReferenceParams>({

--- a/src/hooks/audio/useStemAudioLevels.ts
+++ b/src/hooks/audio/useStemAudioLevels.ts
@@ -52,9 +52,11 @@ export function useStemAudioLevels(
   const [levels, setLevels] = useState<StemLevels>(DEFAULT_LEVELS);
   const nodesRef = useRef<AudioNodes | null>(null);
   const rafRef = useRef<number | null>(null);
-  const dataArrayRef = useRef<Uint8Array | null>(null);
-  const leftDataRef = useRef<Uint8Array | null>(null);
-  const rightDataRef = useRef<Uint8Array | null>(null);
+  // Uint8Array<ArrayBuffer> matches getByteFrequencyData's parameter type
+  // (a bare Uint8Array widens to ArrayBufferLike, which SharedArrayBuffer breaks).
+  const dataArrayRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
+  const leftDataRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
+  const rightDataRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
 
   // Memoize stem volume ratios for level simulation
   const volumeRatios = useMemo(
@@ -133,9 +135,9 @@ export function useStemAudioLevels(
     }
 
     // Get frequency data
-    nodes.analyser.getByteFrequencyData(dataArrayRef.current as any);
-    nodes.leftAnalyser.getByteFrequencyData(leftDataRef.current as any);
-    nodes.rightAnalyser.getByteFrequencyData(rightDataRef.current as any);
+    nodes.analyser.getByteFrequencyData(dataArrayRef.current);
+    nodes.leftAnalyser.getByteFrequencyData(leftDataRef.current);
+    nodes.rightAnalyser.getByteFrequencyData(rightDataRef.current);
 
     // Calculate overall RMS
     const overallRMS = calculateRMS(dataArrayRef.current);

--- a/src/hooks/social/useActivityFeed.ts
+++ b/src/hooks/social/useActivityFeed.ts
@@ -30,6 +30,27 @@ interface FeedPage {
   nextCursor: number | null;
 }
 
+/** Row shape returned by the feed select below (tracks + joined profile). */
+interface FeedTrackRow {
+  id: string;
+  title: string | null;
+  style: string | null;
+  cover_url: string | null;
+  audio_url: string | null;
+  telegram_file_id: string | null;
+  duration_seconds: number | null;
+  created_at: string;
+  likes_count: number | null;
+  play_count: number | null;
+  user_id: string;
+  profiles: {
+    user_id: string;
+    display_name: string | null;
+    username: string | null;
+    photo_url: string | null;
+  } | null;
+}
+
 const PAGE_SIZE = 20;
 
 /**
@@ -143,7 +164,7 @@ export function useActivityFeed(options?: { filter?: "all" | "following" | "like
 
       if (error) throw error;
 
-      const tracks: FeedTrack[] = ((data || []) as any[]).map((track: any) => ({
+      const tracks: FeedTrack[] = ((data || []) as unknown as FeedTrackRow[]).map((track) => ({
         id: track.id,
         title: track.title || "Без названия",
         style: track.style,

--- a/src/hooks/studio/useReplicateMidiTranscription.ts
+++ b/src/hooks/studio/useReplicateMidiTranscription.ts
@@ -15,6 +15,7 @@ export interface ReplicateMidiInput {
 
 export function useReplicateMidiTranscription() {
   return useMutation({
-    mutationFn: (input: ReplicateMidiInput) => invokeReplicateMidiTranscription(input as any),
+    mutationFn: (input: ReplicateMidiInput) =>
+      invokeReplicateMidiTranscription({ ...input, stemId: input.stemId ?? undefined }),
   });
 }

--- a/src/hooks/studio/useStudioHandlers.ts
+++ b/src/hooks/studio/useStudioHandlers.ts
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import type { RecordingType } from "@/components/studio/unified/RecordTrackDrawer";
 import type { StudioOperation } from "@/hooks/studio/useStudioOperationLock";
+import type { SeparableTrack } from "@/hooks/useStemSeparation";
 import type { Database } from "@/integrations/supabase/types";
 
 export interface StudioHandlersOptions {
@@ -52,11 +53,8 @@ export interface StudioHandlersOptions {
     seek: (time: number) => void;
     isPlaying: boolean;
   };
-  trackForSeparation: {
-    id: string;
-    suno_id: string | null;
-  } | null;
-  separate: (track: { id: string; suno_id: string | null }, mode: "simple" | "detailed") => Promise<void>;
+  trackForSeparation: SeparableTrack | null;
+  separate: (track: SeparableTrack, mode: "simple" | "detailed") => Promise<unknown>;
 }
 
 export function useStudioHandlers(options: StudioHandlersOptions) {
@@ -131,7 +129,9 @@ export function useStudioHandlers(options: StudioHandlersOptions) {
       }
 
       try {
-        await separate({ id: trackForSeparation.id, suno_id: trackForSeparation.suno_id }, stemMode);
+        // Pass the full object: the mutation validates audio_url and sends
+        // suno_task_id to the edge function — a narrowed {id, suno_id} fails.
+        await separate(trackForSeparation, stemMode);
         modals.close();
         queryClient.invalidateQueries({ queryKey: ["track-stems", id] });
       } catch (error) {

--- a/src/hooks/studio/useStudioModals.ts
+++ b/src/hooks/studio/useStudioModals.ts
@@ -4,6 +4,9 @@
  */
 
 import { useState, useCallback, useMemo } from "react";
+import type { StudioTrack } from "@/stores/studio/types";
+import type { NotationDrawerProps } from "@/components/studio/unified/NotationDrawer";
+import type { ChordData } from "@/components/studio/unified/ChordOverlay";
 
 // All possible modal types
 export type StudioModalType =
@@ -20,9 +23,18 @@ export type StudioModalType =
   | "chordSheet"
   | "addInstrumental";
 
-interface ModalPayload {
+/**
+ * Studio track enriched with optional analysis artifacts that notation/chord
+ * modals consume. Producers attach them when transcription has completed.
+ */
+export type ModalSelectedTrack = StudioTrack & {
+  transcription?: NotationDrawerProps["transcriptionData"];
+  chords?: ChordData[];
+};
+
+export interface ModalPayload {
   /** Track selected for notation/chords */
-  selectedTrack?: { id: string; title?: string; type?: string; [key: string]: unknown };
+  selectedTrack?: ModalSelectedTrack;
 }
 
 interface ModalState {
@@ -30,7 +42,7 @@ interface ModalState {
   payload: ModalPayload;
 }
 
-interface UseStudioModalsResult {
+export interface UseStudioModalsResult {
   /** Current active modal */
   activeModal: StudioModalType;
   /** Payload data for modal */
@@ -109,11 +121,11 @@ export function useStudioModalHandlers(modals: UseStudioModalsResult, hapticPatt
       openRemix: withHaptic(() => modals.open("remix")),
       openAddVocals: withHaptic(() => modals.open("addVocals")),
       openRecord: withHaptic(() => modals.open("record")),
-      openNotation: (track: { id: string; title?: string; type?: string; [key: string]: unknown }) => {
+      openNotation: (track: ModalSelectedTrack) => {
         hapticPattern?.();
         modals.open("notation", { selectedTrack: track });
       },
-      openChordSheet: (track: { id: string; title?: string; type?: string; [key: string]: unknown }) => {
+      openChordSheet: (track: ModalSelectedTrack) => {
         hapticPattern?.();
         modals.open("chordSheet", { selectedTrack: track });
       },

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -4,6 +4,12 @@ import { useAuth } from "./useAuth";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
 import { useAuditLog } from "./useAuditLog";
+import type { Database } from "@/integrations/supabase/types";
+
+// App-level Artist uses Record metadata; DB rows use the opaque Json type,
+// hence the single documented cast at each write below.
+type ArtistInsert = Database["public"]["Tables"]["artists"]["Insert"];
+type ArtistUpdate = Database["public"]["Tables"]["artists"]["Update"];
 
 export interface Artist {
   id: string;
@@ -55,8 +61,8 @@ export const useArtists = () => {
           {
             user_id: user.id,
             ...artistData,
-          },
-        ] as any)
+          } as unknown as ArtistInsert,
+        ])
         .select()
         .single();
 
@@ -82,7 +88,12 @@ export const useArtists = () => {
 
   const updateArtist = useMutation({
     mutationFn: async ({ id, updates }: { id: string; updates: Partial<Artist> }) => {
-      const { data, error } = await supabase.from("artists").update(updates as any).eq("id", id).select().single();
+      const { data, error } = await supabase
+        .from("artists")
+        .update(updates as unknown as ArtistUpdate)
+        .eq("id", id)
+        .select()
+        .single();
 
       if (error) throw error;
       return data;

--- a/src/hooks/useBotConfig.ts
+++ b/src/hooks/useBotConfig.ts
@@ -47,18 +47,20 @@ export function useBotConfig() {
 
       if (error) throw error;
 
-      const config: Partial<BotConfig> = {};
+      // Values arrive as JSON strings or raw Json; parsed per-key and merged
+      // over defaults, so the unknown-typed accumulator is narrowed at return.
+      const config: Partial<Record<keyof BotConfig, unknown>> = {};
 
       data?.forEach((item) => {
         const key = item.config_key as keyof BotConfig;
         try {
-          (config as any)[key] = typeof item.config_value === "string" ? JSON.parse(item.config_value as string) : item.config_value;
+          config[key] = typeof item.config_value === "string" ? JSON.parse(item.config_value) : item.config_value;
         } catch {
-          (config as any)[key] = item.config_value;
+          config[key] = item.config_value;
         }
       });
 
-      return { ...DEFAULT_CONFIG, ...config } as BotConfig;
+      return { ...DEFAULT_CONFIG, ...(config as Partial<BotConfig>) };
     },
   });
 }

--- a/src/hooks/useKlangioSaveAnalysis.ts
+++ b/src/hooks/useKlangioSaveAnalysis.ts
@@ -32,7 +32,9 @@ export function useKlangioSaveAnalysis() {
 
       const { trackId, analysisType, chords, beats, transcription } = params;
 
-      // Build the analysis data object
+      // Build the analysis data object; metadata is accumulated separately
+      // and assigned once (analysis_metadata column is a Json blob).
+      const metadata: Record<string, unknown> = {};
       const analysisData: Partial<AudioAnalysisInsert> = {
         track_id: trackId,
         user_id: user.id,
@@ -43,12 +45,9 @@ export function useKlangioSaveAnalysis() {
       // Add chord data if available
       if (chords) {
         analysisData.key_signature = chords.key || null;
-        analysisData.analysis_metadata = {
-          ...((analysisData.analysis_metadata as any) || {}),
-          chords: chords.chords,
-          strumming: chords.strumming,
-          chord_count: chords.chords?.length || 0,
-        };
+        metadata.chords = chords.chords;
+        metadata.strumming = chords.strumming;
+        metadata.chord_count = chords.chords?.length || 0;
       }
 
       // Add beat data if available
@@ -60,20 +59,18 @@ export function useKlangioSaveAnalysis() {
           time_signature: beats.time_signature,
         };
         if (beats.time_signature) {
-          analysisData.analysis_metadata = {
-            ...((analysisData.analysis_metadata as any) || {}),
-            time_signature: beats.time_signature,
-          };
+          metadata.time_signature = beats.time_signature;
         }
       }
 
       // Add transcription data if available
       if (transcription) {
-        analysisData.analysis_metadata = {
-          ...((analysisData.analysis_metadata as any) || {}),
-          notes_count: transcription.notes?.length || 0,
-          files: transcription.files,
-        };
+        metadata.notes_count = transcription.notes?.length || 0;
+        metadata.files = transcription.files;
+      }
+
+      if (Object.keys(metadata).length > 0) {
+        analysisData.analysis_metadata = metadata as AudioAnalysisInsert["analysis_metadata"];
       }
 
       // Check if analysis already exists for this track

--- a/src/hooks/usePromptHistorySync.ts
+++ b/src/hooks/usePromptHistorySync.ts
@@ -64,10 +64,10 @@ function loadLocalHistory(): PromptHistoryItem[] {
     if (!Array.isArray(parsed)) return [];
     return parsed.map((item) => {
       const maybeItem = item as Partial<PromptHistoryItem> & { timestamp?: string | number };
+      const rawTimestamp: unknown = maybeItem.timestamp;
       return {
         ...(maybeItem as PromptHistoryItem),
-        timestamp:
-          (maybeItem.timestamp as any) instanceof Date ? (maybeItem.timestamp as any) : new Date(maybeItem.timestamp ?? Date.now()),
+        timestamp: rawTimestamp instanceof Date ? rawTimestamp : new Date(maybeItem.timestamp ?? Date.now()),
       };
     });
   } catch {
@@ -83,10 +83,10 @@ function loadLocalSaved(): SavedPrompt[] {
     if (!Array.isArray(parsed)) return [];
     return parsed.map((item) => {
       const maybeItem = item as Partial<SavedPrompt> & { createdAt?: string | number };
+      const rawCreatedAt: unknown = maybeItem.createdAt;
       return {
         ...(maybeItem as SavedPrompt),
-        createdAt:
-          (maybeItem.createdAt as any) instanceof Date ? (maybeItem.createdAt as any) : new Date(maybeItem.createdAt ?? Date.now()),
+        createdAt: rawCreatedAt instanceof Date ? rawCreatedAt : new Date(maybeItem.createdAt ?? Date.now()),
       };
     });
   } catch {

--- a/src/hooks/useStemSeparation.ts
+++ b/src/hooks/useStemSeparation.ts
@@ -3,12 +3,23 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { logger } from "@/lib/logger";
-import { Track } from "@/types/track";
-
 type SeparationMode = "simple" | "detailed";
 
+/**
+ * Minimal track shape required for stem separation. Full `Track` objects
+ * satisfy this structurally, so callers with narrowed studio objects don't
+ * need casts. The mutation reads audio_url/suno_id for validation and
+ * suno_task_id for the edge function payload.
+ */
+export interface SeparableTrack {
+  id: string;
+  audio_url: string | null;
+  suno_id?: string | null;
+  suno_task_id?: string | null;
+}
+
 interface SeparationParams {
-  track: Track;
+  track: SeparableTrack;
   mode: SeparationMode;
 }
 
@@ -61,13 +72,13 @@ export const useStemSeparation = () => {
   });
 
   const separate = useCallback(
-    (track: Track, mode: SeparationMode) => {
+    (track: SeparableTrack, mode: SeparationMode) => {
       return separateMutation.mutateAsync({ track, mode });
     },
     [separateMutation],
   );
 
-  const canSeparate = useCallback((track: Track) => {
+  const canSeparate = useCallback((track: SeparableTrack) => {
     return !!track.suno_id && !!track.audio_url;
   }, []);
 

--- a/src/hooks/useStemTranscription.ts
+++ b/src/hooks/useStemTranscription.ts
@@ -7,6 +7,9 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { logger } from "@/lib/logger";
 import { toast } from "sonner";
+import type { Database } from "@/integrations/supabase/types";
+
+type StemTranscriptionInsert = Database["public"]["Tables"]["stem_transcriptions"]["Insert"];
 
 const log = logger.child({ module: "StemTranscription" });
 
@@ -183,7 +186,7 @@ export function useSaveTranscription() {
         .eq("model", params.model)
         .maybeSingle();
 
-      const transcriptionData = {
+      const transcriptionData: StemTranscriptionInsert = {
         stem_id: params.stemId,
         track_id: params.trackId,
         user_id: user.id,
@@ -193,7 +196,9 @@ export function useSaveTranscription() {
         gp5_url: params.gp5Url,
         pdf_url: params.pdfUrl,
         model: params.model,
-        notes: params.notes,
+        // TranscriptionNote[] is structurally Json-compatible; the generated
+        // column type is the opaque Json union, hence the single cast here.
+        notes: (params.notes ?? null) as StemTranscriptionInsert["notes"],
         notes_count: params.notesCount,
         bpm: params.bpm,
         key_detected: params.keyDetected,
@@ -207,7 +212,7 @@ export function useSaveTranscription() {
         // Update existing
         const { data, error } = await supabase
           .from("stem_transcriptions")
-          .update(transcriptionData as any)
+          .update(transcriptionData)
           .eq("id", existing.id)
           .select()
           .single();
@@ -217,7 +222,7 @@ export function useSaveTranscription() {
         return data as StemTranscription;
       } else {
         // Insert new
-        const { data, error } = await supabase.from("stem_transcriptions").insert(transcriptionData as any).select().single();
+        const { data, error } = await supabase.from("stem_transcriptions").insert(transcriptionData).select().single();
 
         if (error) throw error;
         log.info("Transcription saved", { stemId: params.stemId });

--- a/src/hooks/useTrackVersionManagement.tsx
+++ b/src/hooks/useTrackVersionManagement.tsx
@@ -57,7 +57,7 @@ export function useTrackVersionManagement() {
       toast.success("Версия создана из основного трека");
     } catch (error) {
       logger.error("Create version error", error);
-      toast.error((error as any)?.message || "Ошибка создания версии");
+      toast.error(error instanceof Error ? error.message : "Ошибка создания версии");
     } finally {
       setIsProcessing(false);
     }
@@ -92,7 +92,15 @@ export function useTrackVersionManagement() {
       if (setPrimaryError) throw setPrimaryError;
 
       // Update main track with version data including title and metadata
-      const metadata = ((version as any).metadata ?? null) as any;
+      // Version metadata is a Json blob; narrow to the fields consumed below.
+      const metadata = (version.metadata ?? null) as {
+        title?: string | null;
+        prompt?: string | null;
+        tags?: string[] | null;
+        lyrics?: string | null;
+        style?: string | null;
+        model_name?: string | null;
+      } | null;
       const versionTitle =
         metadata?.title || (typeof metadata?.prompt === "string" ? metadata.prompt.split("\n")[0] : null) || null;
 
@@ -140,7 +148,7 @@ export function useTrackVersionManagement() {
       await queryClient.invalidateQueries({ queryKey: ["track-versions", trackId] });
     } catch (error) {
       logger.error("Set primary error", error);
-      toast.error((error as any)?.message || "Ошибка установки версии");
+      toast.error(error instanceof Error ? error.message : "Ошибка установки версии");
     } finally {
       setIsProcessing(false);
     }
@@ -156,7 +164,7 @@ export function useTrackVersionManagement() {
       toast.success("Версия удалена");
     } catch (error) {
       logger.error("Delete version error", error);
-      toast.error((error as any)?.message || "Ошибка удаления версии");
+      toast.error(error instanceof Error ? error.message : "Ошибка удаления версии");
     } finally {
       setIsProcessing(false);
     }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -95,7 +95,7 @@ export default function Settings() {
       case "notifications":
         return (
           <NotificationsTab
-            settings={settings.notificationSettings as any}
+            settings={settings.notificationSettings as Record<string, unknown> | null | undefined}
             isUpdating={settings.isUpdating}
             onToggle={settings.toggleNotification}
             onUpdateSettings={settings.updateSettings}

--- a/src/pages/lyrics-studio/LyricsFooter.tsx
+++ b/src/pages/lyrics-studio/LyricsFooter.tsx
@@ -61,23 +61,10 @@ export function LyricsFooter({
 }: LyricsFooterProps) {
   return (
     <>
-      {/* Section Notes Panel */}
-      {selectedSection && (
-        <SectionNotesPanel
-          {...({
-            open: notesPanelOpen,
-            onOpenChange: onNotesOpenChange,
-            sectionId: selectedSection.id,
-            sectionType: selectedSection.type,
-            sectionContent: selectedSection.content,
-            position: sections.findIndex((s) => s.id === selectedSection.id),
-            existingNote,
-            lyricsTemplateId,
-            onSave: onSaveNote,
-            onEnrichWithTags,
-          } as any)}
-        />
-      )}
+      {/* Section Notes Panel. Its public API is only {sectionId, className, maxHeight};
+          the legacy extra props (open, onSave, …) were always silently ignored, so they
+          are no longer forwarded — runtime behaviour is unchanged. */}
+      {selectedSection && <SectionNotesPanel sectionId={selectedSection.id} />}
 
       {/* Versions Panel */}
       <LyricsVersionsPanel

--- a/src/pages/lyrics-studio/__tests__/LyricsFooter.test.tsx
+++ b/src/pages/lyrics-studio/__tests__/LyricsFooter.test.tsx
@@ -90,11 +90,15 @@ describe("LyricsFooter", () => {
     expect(props.open).toBe(true);
   });
 
-  it("passes notesPanelOpen=true to SectionNotesPanel", () => {
+  it("passes only the supported sectionId prop to SectionNotesPanel", () => {
+    // SectionNotesPanel's public API is {sectionId, className, maxHeight};
+    // legacy extra props (open, onSave, …) were always ignored by the panel
+    // and are no longer forwarded.
     render(<LyricsFooter {...baseProps} notesPanelOpen={true} />);
     const panel = screen.getByTestId("section-notes-panel");
     const props = JSON.parse(panel.getAttribute("data-props") || "{}");
-    expect(props.open).toBe(true);
+    expect(props.sectionId).toBe(sampleSection.id);
+    expect(props.open).toBeUndefined();
   });
 
   it("forwards restore and delete callbacks to LyricsVersionsPanel", () => {

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -106,7 +106,7 @@ export async function sendAdminMessageToUsers(payload: {
 // Subscription management (admin)
 // ==========================================
 
-import { updateUserProfile } from "@/api/profiles.api";
+import { updateUserProfile, type ProfileUpdate } from "@/api/profiles.api";
 import { insertCreditTransaction } from "@/api/payments.api";
 
 /**
@@ -123,12 +123,9 @@ export async function changeUserSubscriptionTier(payload: {
   currentTier?: string;
   reason?: string;
 }): Promise<void> {
-  const updates: {
-    subscription_tier: string;
-    updated_at: string;
-    subscription_expires_at?: string | null;
-  } = {
-    subscription_tier: payload.tier,
+  const updates: ProfileUpdate = {
+    // Callers pass validated tier strings; the column type is the DB enum.
+    subscription_tier: payload.tier as ProfileUpdate["subscription_tier"],
     updated_at: new Date().toISOString(),
   };
 
@@ -138,7 +135,7 @@ export async function changeUserSubscriptionTier(payload: {
     updates.subscription_expires_at = null;
   }
 
-  await updateUserProfile(payload.userId, updates as any);
+  await updateUserProfile(payload.userId, updates);
 
   await insertCreditTransaction({
     user_id: payload.userId,

--- a/src/services/audio-reference/reference-analysis.service.ts
+++ b/src/services/audio-reference/reference-analysis.service.ts
@@ -7,7 +7,20 @@
  */
 
 import { invokeReferenceAudioAnalysis } from "@/api/analysis.api";
-type ReferenceAnalysis = any;
+
+/** Normalized analysis result extracted from the analyze-reference-audio edge function. */
+export interface ReferenceAnalysis {
+  bpm?: number;
+  key?: string;
+  genre?: string;
+  mood?: string;
+  energy?: string;
+  instruments?: string[];
+  chords?: string[];
+  style_description?: string;
+  vocal_style?: string;
+  suggested_tags?: string[];
+}
 
 export interface AnalyzeReferenceParams {
   audioUrl: string;

--- a/src/services/gamification/missions.service.ts
+++ b/src/services/gamification/missions.service.ts
@@ -143,8 +143,9 @@ export async function fetchSpecialChallengeStats(userId: string): Promise<Specia
   return {
     totalTracks,
     totalLikes,
-    longestStreak: (credits as any)?.longest_streak ?? 0,
-    level: (credits as any)?.level ?? 1,
+    // getUserCredits returns a {data, error} envelope — read the row inside it.
+    longestStreak: credits.data?.longest_streak ?? 0,
+    level: credits.data?.level ?? 1,
     artistsCount,
     achievementsCount,
   };
@@ -183,6 +184,6 @@ export async function fetchWeeklyChallengeStats(
     generations,
     shares,
     likesReceived,
-    currentStreak: (credits as any)?.current_streak ?? 0,
+    currentStreak: credits.data?.current_streak ?? 0,
   };
 }

--- a/src/services/lyrics/ai-tools.service.ts
+++ b/src/services/lyrics/ai-tools.service.ts
@@ -35,7 +35,7 @@ export async function sendAiChatMessage({ message, context }: ChatParams) {
     action: "chat",
     message,
     context,
-  } as any);
+  });
   return { data, error };
 }
 
@@ -71,7 +71,7 @@ export async function generateLyrics(params: GenerateLyricsParams) {
     mood: params.mood,
     structure: params.structure,
     language: params.language,
-  } as any);
+  });
 }
 
 /**


### PR DESCRIPTION
UI component audit: bring ESLint to 0 errors by replacing every explicit
\`any\` with real types across 26 files (studio components, hooks, services,
pages). Two real defects surfaced and fixed along the way:

- Stem separation from mobile studio always failed: useStudioHandlers
  passed a narrowed {id, suno_id} object to separate(), but the mutation
  validates audio_url and sends suno_task_id to the edge function. It now
  passes the full track via the new structural SeparableTrack type.
- Special/weekly challenge stats always showed streak 0 and level 1:
  missions.service read longest_streak/level/current_streak off the
  {data, error} envelope returned by getUserCredits instead of the row.

Typing improvements:
- Wavesurfer timelines use real wavesurfer.js v7 types instead of any/
  hand-rolled structural types
- Studio modal payload (selectedTrack) is a typed StudioTrack enriched
  with transcription/chords, removing 7 casts in StudioDialogs
- Supabase writes use generated Insert/Update types (artists,
  stem_transcriptions, profiles, audio_analysis)
- recharts tooltip/legend payload items use library-provided Payload types
- Audio analyser buffers typed as Uint8Array<ArrayBuffer>
- LyricsFooter no longer forwards legacy no-op props to SectionNotesPanel
  (its public API is {sectionId, className, maxHeight}); test updated to
  the real contract

Verified: tsc clean, eslint 0 errors, 288 unit tests pass, production
build succeeds with no circular chunk warnings.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017jXPhUCaKSRJn5P5CUvM6u