### PR TITLE
fix(types): repair sprint-052 typecheck breakage on main + work plan 050–055

### DIFF
--- a/SPRINTS/WORK-PLAN-2026-07-04.md
+++ b/SPRINTS/WORK-PLAN-2026-07-04.md
@@ -34,6 +34,14 @@
 
 **Выход:** hotfix-PR → `main` зелёный по Quality & Build.
 
+**✅ Выполнено (тот же день, ветка `claude/project-progress-sprint-plan-150yf8`):** обе правки внесены (`MashupDialog` — деструктуризация `tracks`; `SunoMashupParams`/`SunoPersonaParams` — `interface` → `type` для implicit index signature). Ошибка в `MashupDialog` была ещё и runtime-багом: пикеры треков Mashup всегда оставались пустыми. Верификация: `tsc` 0 ошибок, ESLint 0 ошибок, unit 292/292 (добавлен регрессионный тест `src/__tests__/components/MashupDialog.test.tsx`, 4 теста), production build + `size-limit` — все 9 бюджетов в норме, E2E deep-link смоук mashup — pass локально.
+
+**🆕 Находки при верификации (входы в Sprint 050/051):**
+
+1. **25 тест-файлов в `tests/unit/` никогда не запускаются**: `vitest.config.ts` включает только `src/**/*.test.{ts,tsx}`, тогда как CLAUDE.md заявляет паттерн `tests/unit/**` как рабочий. Либо расширить include (и починить то, что упадёт), либо перенести файлы в `src/__tests__/` — задача для Sprint 051 (Test Debt).
+2. `tests/e2e/suno-mashup.spec.ts` использует `waitForLoadState("networkidle")` — хрупкий паттерн (не наступает при постоянных фоновых запросах Sentry/Supabase); в CI может флейкать. Кандидат на замену локатор-ожиданием в 050-A1.
+3. Глобальный мок `ResizeObserver` в vitest setup — arrow-factory, не конструктор: любой компонент с Radix popper (`new ResizeObserver()`) в тестах падает. Локально обойдено в тесте; глобальный фикс — в Sprint 051.
+
 ---
 
 ## 3. Sprint 050 — Main Green + Mobile Audit F1–F12 (~10 дней)

--- a/src/__tests__/components/MashupDialog.test.tsx
+++ b/src/__tests__/components/MashupDialog.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * MashupDialog Unit Tests
+ *
+ * Регрессия на hotfix Sprint 052: компонент должен читать `tracks`
+ * (а не `data`) из useTracks — иначе пикеры треков остаются пустыми.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { MashupDialog } from "@/components/MashupDialog";
+
+vi.mock("@/hooks/useTracks", () => ({
+  useTracks: () => ({
+    tracks: [
+      { id: "track-a", title: "Track One" },
+      { id: "track-b", title: "Track Two" },
+    ],
+  }),
+}));
+
+vi.mock("@/hooks/studio/useSunoMashup", () => ({
+  useSunoMashup: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+// Тянет useTelegram/TelegramProvider — вне рамок этого unit-теста
+vi.mock("@/components/generate-form/PromptValidationAlert", () => ({
+  PromptValidationAlert: () => null,
+}));
+
+describe("MashupDialog", () => {
+  beforeAll(() => {
+    // Radix Select в jsdom: pointer-capture и scrollIntoView отсутствуют
+    Element.prototype.hasPointerCapture = vi.fn();
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+    Element.prototype.scrollIntoView = vi.fn();
+    // Глобальный мок из setup — не конструктор; Radix popper делает `new ResizeObserver()`
+    globalThis.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    };
+  });
+
+  it("renders dialog with track pickers when open", async () => {
+    render(<MashupDialog open={true} onOpenChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Смешайте два своих трека в один")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Трек A *")).toBeInTheDocument();
+    expect(screen.getByText("Трек B *")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<MashupDialog open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByText("Трек A *")).not.toBeInTheDocument();
+  });
+
+  it("populates track A options from useTracks().tracks (hotfix regression)", async () => {
+    render(<MashupDialog open={true} onOpenChange={() => {}} />);
+
+    const triggers = await screen.findAllByRole("combobox");
+    // Радикс-селект открывается с клавиатуры — надёжно в jsdom
+    fireEvent.keyDown(triggers[0], { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Track One" })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("option", { name: "Track Two" })).toBeInTheDocument();
+  });
+
+  it("excludes track A from track B options", async () => {
+    render(<MashupDialog open={true} onOpenChange={() => {}} initialTrackId="track-a" />);
+
+    const triggers = await screen.findAllByRole("combobox");
+    fireEvent.keyDown(triggers[1], { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Track Two" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("option", { name: "Track One" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 📝 Описание

P0-хотфикс: `main` красный по Quality & Build — 8 ошибок `tsc` в коде Sprint 052 (воспроизведены локально на HEAD `f6a9b9f`).

1. **`src/components/MashupDialog.tsx`** — компонент деструктурировал `data` из `useTracks()`, а хук возвращает `tracks`. Это была не только ошибка типов, но и **runtime-баг**: пикеры треков Mashup всегда оставались пустыми (фича неработоспособна). Исправление попутно убрало 5 implicit-`any` ошибок.
2. **`src/services/studio.service.ts`** — `SunoMashupParams` / `SunoPersonaParams` переведены с `interface` на `type`-алиасы: интерфейсы не получают implicit index signature, требуемую `[key: string]: unknown` в сигнатурах `studioApi.invokeSunoMashup/invokeSunoPersona`. Без изменений в runtime.
3. **`src/__tests__/components/MashupDialog.test.tsx`** — 4 регрессионных теста: опции пикеров заполняются из `useTracks().tracks`, трек A исключается из списка трека B.
4. **`SPRINTS/WORK-PLAN-2026-07-04.md`** — консолидированный план работ P0 → Sprint 050–055 (по итогам ревизии прогресса и живой проверки CI) + находки верификации.

## 🎯 Тип изменения

- [x] 🐛 Bug fix (исправление ошибки)
- [x] ✅ Tests (добавление или обновление тестов)
- [x] 📚 Documentation (только изменения документации)

## 🔗 Связанные Issues

Related to: Sprint 050 (Main Green), SPRINTS/SPRINT-050-PLAN.md

## 📋 Чеклист перед созданием PR

### 🔍 Код

- [x] Мой код следует стайл-гайду этого проекта
- [x] Я провел самопроверку своего кода
- [x] Мои изменения не генерируют новых предупреждений

### 📚 Документация

- [x] Я обновил документацию (WORK-PLAN-2026-07-04.md)

### ✅ Тестирование

- [x] Я добавил тесты, подтверждающие правильность моего исправления (4 unit-теста)
- [x] Новые и существующие unit тесты проходят локально (292/292, 20 suites)
- [x] Все существующие тесты все еще проходят

### 🔨 Сборка

- [x] `npm run build` выполняется успешно
- [x] `npm run lint` не показывает ошибок (изменённые файлы: 0 errors)
- [x] `npm run test` проходит успешно
- [x] `npm run format` применен к измененным файлам (pre-commit hooks)

### 🔐 Безопасность

- [x] Мои изменения не вводят уязвимостей безопасности
- [x] Я не коммичу секреты, ключи или чувствительные данные

## 🧪 Тестирование

### Сценарии тестирования

1. `npm run typecheck` (`tsc --build --force`) — 0 ошибок (было 8 на `main`)
2. `npm test` — 292/292 passed, включая 4 новых регрессионных теста MashupDialog
3. `npm run build` + `npm run size` — сборка успешна, все 9 size-limit бюджетов в норме
4. E2E deep-link смоук `tests/e2e/suno-mashup.spec.ts` — pass локально (второй тест спеки завис на `networkidle` из-за фоновых запросов в песочнице — ограничение среды, отмечено в плане как кандидат на фикс в 050-A1)

## ⚡ Влияние на производительность

- **Размер bundle:** без изменений (правки типов + деструктуризация)

## 🔄 Миграция

Требуется ли миграция?

- [x] Нет

## 📝 Дополнительные заметки

Находки верификации (зафиксированы в WORK-PLAN, входы для Sprint 050/051):

- 25 тест-файлов в `tests/unit/` **никогда не запускаются**: `vitest.config.ts` включает только `src/**/*.test.{ts,tsx}` (CLAUDE.md заявляет иначе)
- Глобальный мок `ResizeObserver` в vitest setup — не конструктор; компоненты с Radix popper падают в тестах
- `main` перезаписывается force-push'ем (зафиксирован `forced update 4ec3684...f6a9b9f`) — вливать этот PR стоит быстро, до следующего пуша Lovable; системное решение — 050-A4 (branch protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5UEwTwwEFds7aMBHCdKsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5UEwTwwEFds7aMBHCdKsG)_