### PR TITLE
docs: fix broken links in guides and templates (sprint 050 a2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ flowchart LR
 
 - Search [issues](https://github.com/HOW2AI-AGENCY/aimusicverse/issues) first.
 - Use the templates: bug · feature · docs · performance.
-- For larger work, open a [discussion](https://github.com/HOW2AI-AGENCY/aimusicverse/discussions) first.
+- For larger work, open an [issue](https://github.com/HOW2AI-AGENCY/aimusicverse/issues/new) first.
 
 ## 2. Branching
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -382,7 +382,6 @@ npm run build
 
 ### Сообщество
 
-- 💬 [GitHub Discussions](https://github.com/HOW2AI-AGENCY/aimusicverse/discussions)
 - 🐛 [Сообщить о проблеме](https://github.com/HOW2AI-AGENCY/aimusicverse/issues)
 - 📧 [Email Support](mailto:support@musicverse.ai)
 - 💬 [Telegram Support](https://t.me/MusicVerseSupport)

--- a/docs/TELEGRAM_BOT_USER_GUIDE_RU.md
+++ b/docs/TELEGRAM_BOT_USER_GUIDE_RU.md
@@ -509,7 +509,6 @@ A:
 ### Полезные ссылки
 
 - [Документация API](https://docs.musicverse.ai)
-- [Примеры треков](https://musicverse.ai/examples)
 - [Сообщество](https://t.me/AIMusicVerseCommunity)
 - [YouTube канал](https://youtube.com/@AIMusicVerse)
 

--- a/docs/templates/FOOTER_TEMPLATE.md
+++ b/docs/templates/FOOTER_TEMPLATE.md
@@ -8,12 +8,12 @@
 
 ### 🔗 Related Documentation
 
-|                     📚 Index                     |               🏛 Architecture               |        🗺 Roadmap         |          🤝 Contributing           |        🔒 Security         |         📝 Changelog         |
-| :----------------------------------------------: | :----------------------------------------: | :----------------------: | :--------------------------------: | :------------------------: | :--------------------------: |
-| [DOCUMENTATION_INDEX](../DOCUMENTATION_INDEX.md) | [ARCHITECTURE_HUB](../ARCHITECTURE_HUB.md) | [ROADMAP](../ROADMAP.md) | [CONTRIBUTING](../CONTRIBUTING.md) | [SECURITY](../SECURITY.md) | [CHANGELOG](../CHANGELOG.md) |
+|                      📚 Index                       |                🏛 Architecture                 |          🗺 Roadmap          |            🤝 Contributing            |          🔒 Security          |          📝 Changelog           |
+| :-------------------------------------------------: | :-------------------------------------------: | :-------------------------: | :-----------------------------------: | :---------------------------: | :-----------------------------: |
+| [DOCUMENTATION_INDEX](../../DOCUMENTATION_INDEX.md) | [ARCHITECTURE_HUB](../../ARCHITECTURE_HUB.md) | [ROADMAP](../../ROADMAP.md) | [CONTRIBUTING](../../CONTRIBUTING.md) | [SECURITY](../../SECURITY.md) | [CHANGELOG](../../CHANGELOG.md) |
 
 **Made with ❤️ by the [MusicVerse AI](https://github.com/HOW2AI-AGENCY/aimusicverse) team**
 
-<sub>Last updated: <!-- DATE --> · [Report issue](https://github.com/HOW2AI-AGENCY/aimusicverse/issues/new) · [Discuss](https://github.com/HOW2AI-AGENCY/aimusicverse/discussions)</sub>
+<sub>Last updated: <!-- DATE --> · [Report issue](https://github.com/HOW2AI-AGENCY/aimusicverse/issues/new)</sub>
 
 </div>

--- a/docs/templates/HEADER_TEMPLATE.md
+++ b/docs/templates/HEADER_TEMPLATE.md
@@ -16,11 +16,11 @@
 </p>
 
 <p>
-  <a href="../README.md">🏠 Home</a> ·
-  <a href="../DOCUMENTATION_INDEX.md">📚 Docs Index</a> ·
-  <a href="../ARCHITECTURE_HUB.md">🏛 Architecture</a> ·
-  <a href="../ROADMAP.md">🗺 Roadmap</a> ·
-  <a href="../CHANGELOG.md">📝 Changelog</a>
+  <a href="../../README.md">🏠 Home</a> ·
+  <a href="../../DOCUMENTATION_INDEX.md">📚 Docs Index</a> ·
+  <a href="../../ARCHITECTURE_HUB.md">🏛 Architecture</a> ·
+  <a href="../../ROADMAP.md">🗺 Roadmap</a> ·
+  <a href="../../CHANGELOG.md">📝 Changelog</a>
 </p>
 
 </div>


### PR DESCRIPTION
## Что изменено

Починка битых ссылок в документации (Sprint 050, задача A2).

- **CONTRIBUTING.md** — ссылка на GitHub Discussions заменена на создание issue (Discussions в репозитории не включены).
- **docs/QUICK_START.md** — удалена мёртвая ссылка на GitHub Discussions из раздела «Сообщество».
- **docs/TELEGRAM_BOT_USER_GUIDE_RU.md** — удалена мёртвая ссылка «Примеры треков» (`musicverse.ai/examples`).
- **docs/templates/FOOTER_TEMPLATE.md** и **HEADER_TEMPLATE.md** — исправлена глубина относительных путей (`../` → `../../`), чтобы ссылки на корневые доки (README, ROADMAP, ARCHITECTURE_HUB и т.д.) корректно разрешались из подкаталога `docs/templates/`; удалена ссылка на Discussions из футера.

## Почему

Ссылки вели на несуществующие страницы (Discussions не активированы, страница examples отсутствует), а относительные пути в шаблонах были на один уровень выше нужного, из-за чего навигация из сгенерированных по шаблону доков ломалась.

## Для ревьюера

- Изменения только в markdown, кода не касаются.
- ✅ Pre-commit hooks и TypeScript type check прошли.

🤖 Generated with [Claude Code](https://claude.com/claude-code)