### PR TITLE
fix(build): remove duplicate mcpPlugin declaration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,6 @@ let mcpPlugin: (() => Plugin) | undefined;
 let visualizer: ((opts: Record<string, unknown>) => Plugin) | undefined;
 let viteCompression: ((opts: Record<string, unknown>) => Plugin) | undefined;
 let hasTerser = false;
-let mcpPlugin: (() => Plugin) | undefined;
 
 try {
   // @ts-ignore — types only exist inside the Lovable pipeline


### PR DESCRIPTION
Removes duplicate let mcpPlugin in vite.config.ts that causes TS2451 in CI (Quality & Build, E2E, CI/CD Pipeline all fail).