### PR TITLE
docs: add thin orchestrator pattern and migration guide

### DIFF
--- a/docs/GENERATESHEET-MIGRATION-GUIDE.md
+++ b/docs/GENERATESHEET-MIGRATION-GUIDE.md
@@ -1,0 +1,56 @@
+# GenerateSheet Migration Guide
+
+**Sprint 056 — Component Decomposition**
+
+## What Changed
+
+GenerateSheet was refactored from a monolithic ~800 LOC component to a thin orchestrator pattern with specialized sub-components.
+
+## For Consumers
+
+### No Breaking Changes
+
+The public API of GenerateSheet remains unchanged:
+
+```tsx
+<GenerateSheet value={lyrics} onChange={setLyrics} onAIGenerate={handleAI} />
+```
+
+### Internal Architecture
+
+If you were importing internal components or hooks:
+
+1. **`useGenerateFormState`** → Now split into:
+   - `useGenerateSheetController` — state management
+   - `useGenerateSheetValidation` — validation logic
+
+2. **`GenerateSheet` internals** → Now composed of:
+   - `GenerateSheetHeader` — balance, mode selector, model picker
+   - `GenerateSheetBody` — prompt input, lyrics editor, references
+   - `GenerateSheetFooter` — generate button, save draft, cost summary
+   - `GenerateSheetDialogs` — all dialog components
+
+### For Storybook
+
+New stories available for each sub-component:
+
+```tsx
+import { GenerateSheet } from "@/components/generate-form/GenerateSheet";
+import { AdvancedSettings } from "@/components/generate-form/AdvancedSettings";
+import { ReferenceChipsRow } from "@/components/generate-form/ReferenceChipsRow";
+```
+
+## Testing
+
+Each sub-component can now be tested in isolation:
+
+```tsx
+render(<GenerateSheetHeader {...mockProps} />);
+render(<GenerateSheetBody {...mockProps} />);
+```
+
+## Related Documentation
+
+- [Thin Orchestrator Pattern](./THIN-ORCHESTRATOR-PATTERN.md)
+- [Component Architecture](./COMPONENTS.md)
+- [Sprint 056 Plan](../SPRINTS/SPRINT-056-PLAN.md)

--- a/docs/THIN-ORCHESTRATOR-PATTERN.md
+++ b/docs/THIN-ORCHESTRATOR-PATTERN.md
@@ -1,0 +1,57 @@
+# Thin Orchestrator Pattern
+
+**GenerateSheet decomposition — Sprint 056**
+
+## Overview
+
+GenerateSheet uses a "thin orchestrator" pattern where the main component delegates responsibility to specialized sub-components. The orchestrator owns state management and event routing but delegates rendering to focused components.
+
+## Architecture
+
+```
+GenerateSheet (orchestrator)
+├── GenerateSheetHeader (balance, mode, model, history)
+├── GenerateSheetBody (prompt, lyrics, references, advanced)
+├── GenerateSheetFooter (generate, save draft, cost summary)
+└── GenerateSheetDialogs (project, artist, audio, voice, history, styles)
+```
+
+## Benefits
+
+1. **Single Responsibility** — each component has one clear job
+2. **Composition over Inheritance** — components assembled from smaller blocks
+3. **Props-Driven Interface** — all control through props, minimal internal state
+4. **Improved Testability** — sub-components testable in isolation
+5. **Reusability** — sub-components usable in other contexts
+
+## Implementation
+
+```tsx
+// GenerateSheet — thin orchestrator
+export function GenerateSheet({ value, onChange }: Props) {
+  const controller = useGenerateSheetController(value, onChange);
+
+  return (
+    <Sheet>
+      <GenerateSheetHeader {...controller.headerProps} />
+      <GenerateSheetBody {...controller.bodyProps} />
+      <GenerateSheetFooter {...controller.footerProps} />
+      <GenerateSheetDialogs {...controller.dialogProps} />
+    </Sheet>
+  );
+}
+```
+
+## Key Principles
+
+- Orchestrator owns state via `useGenerateSheetController` hook
+- Sub-components receive props, never reach into parent state
+- Dialogs managed centrally but rendered by specialized components
+- Validation logic extracted to `useGenerateSheetValidation` hook
+
+## Related Files
+
+- `src/components/generate-form/GenerateSheet.tsx` — orchestrator
+- `src/hooks/useGenerateSheetController.ts` — state management
+- `src/hooks/useGenerateSheetValidation.ts` — validation logic
+- `docs/COMPONENTS.md` — component architecture overview


### PR DESCRIPTION
## Summary

- Add THIN-ORCHESTRATOR-PATTERN.md documenting the architecture pattern
- Add GENERATESHEET-MIGRATION-GUIDE.md for existing consumers
- Sprint 056 Phase D documentation complete

## Changes

| File | Description |
|---|---|
| docs/THIN-ORCHESTRATOR-PATTERN.md | New: architecture pattern documentation |
| docs/GENERATESHEET-MIGRATION-GUIDE.md | New: migration guide for consumers