### PR TITLE
docs: Sprint 065 closure — Storybook stories + CLAUDE.md sync

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,8 @@ node_modules
 
 # Ignore Supabase generated files
 supabase/functions/suno-api/index.ts
+# Auto-generated & bundled by the @lovable.dev/mcp-js Vite plugin (banner in file); never hand-edited.
+supabase/functions/mcp/index.ts
 src/integrations/supabase/types.ts
 
 # Ignore graphify cache (auto-generated)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **MusicVerse AI** is a professional AI-powered music creation platform delivered as a Telegram Mini App. Built with React 19, TypeScript, and Vite, it integrates Suno AI v5 for music generation with extensive editing, mixing, and collaboration features.
 
-- **Technology Stack:** React 19.2 + TypeScript 5.9 + Vite 5.0
+- **Technology Stack:** React 19.2 + TypeScript 5.9 + Vite 8.1
 - **Backend:** Supabase (PostgreSQL + Edge Functions + Storage)
 - **UI Framework:** Tailwind CSS 3.4 + shadcn/ui + Radix UI
 - **State Management:** Zustand 5.0 (global) + TanStack Query 5.90 (server state)
 - **Audio Processing:** Tone.js 14.9, Wavesurfer.js 7.8
 - **Telegram Integration:** @twa-dev/sdk 8.0.2
-- **Testing:** Vitest 4.x (unit), Playwright 1.57 (E2E)
+- **Testing:** Vitest 4.x (unit), Playwright 1.61 (E2E)
 
 ## Development Commands
 
@@ -56,17 +56,17 @@ The application follows a layered architecture:
 
 ```
 ┌─────────────────────────────────────────────┐
-│  Pages (76)                                 │  Route-level components with lazy loading
+│  Pages (74)                                 │  Route-level components with lazy loading
 ├─────────────────────────────────────────────┤
-│  Components (1136)                          │  Feature-specific & UI components
+│  Components (~1043)                         │  Feature-specific & UI components
 ├─────────────────────────────────────────────┤
-│  Hooks (419)                                │  Reusable React logic
+│  Hooks (440)                                │  Reusable React logic
 ├─────────────────────────────────────────────┤
-│  Services (56)                              │  Business logic & data transformation
+│  Services (37)                              │  Business logic & data transformation
 ├─────────────────────────────────────────────┤
-│  API Layer (24)                             │  Direct Supabase queries
+│  API Layer (30)                             │  Direct Supabase queries
 ├─────────────────────────────────────────────┤
-│  Stores (27 Zustand)                        │  Global state (player, studio, lyrics)
+│  Stores (24 Zustand)                        │  Global state (player, studio, lyrics)
 └─────────────────────────────────────────────┘
 ```
 
@@ -79,11 +79,11 @@ The application follows a layered architecture:
 
 ### Critical Directory Purposes
 
-- **`src/api/`** (24 files) - Direct Supabase database operations, type-safe queries
-- **`src/services/`** (56 files) - Business logic layer, data transformation, complex operations
-- **`src/hooks/`** (419 files) - Custom React hooks for UI logic and state management
-- **`src/stores/`** (27 files) - Zustand stores for complex global state (player, unified studio, lyrics)
-- **`src/components/`** (1136 files) - React components organized by feature
+- **`src/api/`** (30 files) - Direct Supabase database operations, type-safe queries
+- **`src/services/`** (37 files) - Business logic layer, data transformation, complex operations
+- **`src/hooks/`** (440 files) - Custom React hooks for UI logic and state management
+- **`src/stores/`** (24 stores) - Zustand stores for complex global state (player, unified studio, lyrics)
+- **`src/components/`** (~1043 files) - React components organized by feature
   - `ui/` - shadcn/ui base components + custom components (LazyImage, GlowButton, etc.)
   - `player/` - Audio player (CompactPlayer, ExpandedPlayer, MobileFullscreenPlayer)
   - `generate-form/` - Music generation form modules
@@ -505,11 +505,11 @@ Logger persists to sessionStorage and integrates with Sentry.
 
 **Current Status:**
 
-- Sprint: **051 ✅ Complete** (Test Debt Phase A-C: god-file decomposition 9/9 done + API/Service тесты), Sprint **055 ✅ Complete** (UX P0/P1 Fixes 13/13), Sprint **056 ✅ Complete** (GenerateSheet Redesign + Storybook), Sprint **053+054 ✅ Complete** (Suno API 28/28 — 100% покрытие). Design-review проведён 2026-07-06 (Score C+, AI Slop B). План на 2-4 недели — [FUTURE_WORK_PLAN.md](FUTURE_WORK_PLAN.md).
+- Sprint: **065 🔄 In progress** (Generate v2 + Home Redesign + Visual Regression). Recent: Sprint **056 ✅** (GenerateSheet Redesign + Storybook), **055 ✅** (UX P0/P1 13/13), **053+054 ✅** (Suno API 28/28), **051 ✅** (Test Debt A-C). Security audit 2026-07-13 — all 3 P0 findings (open notification endpoint, unsigned Suno callbacks, unmasked Sentry Replay) ✅ remediated. Canonical plan & backlog (066–069): [WORKPLAN-2026-07-14.md](WORKPLAN-2026-07-14.md).
 - Architecture Audit: Complete (2026-06-28) — score 6.1/10, plan to 8.4/10
-- Components: 1161, Hooks: 434, Stores: 24 (12 top-level + 12 in domain slices under `src/stores/*/`), API files: 30, Services: 37 *.service.ts (12 top-level + 25 in domain subfolders under `src/services/*/`) — recursive `find`/`wc -l` count, verified 2026-07-07 (see [docs/audit/PROGRESS-AUDIT-2026-07-07.md](docs/audit/PROGRESS-AUDIT-2026-07-07.md)). Previous snapshot (1037/413/12/26/12, verified 2026-07-06) undercounted files nested in domain subfolders.
+- Components: ~1043 (`src/components/*.tsx`), Hooks: 440, Stores: 24 (12 top-level + 12 in domain slices under `src/stores/*/`), API files: 30, Services: 37 *.service.ts, Stories: 59 — recursive `find`/`wc -l` count, verified 2026-07-14 (see [WORKPLAN-2026-07-14.md](WORKPLAN-2026-07-14.md)).
 - Bundle Size: ~508 KB gzip eager JS; 2.11 MB total across all chunks. См. [docs/BUNDLE_ANALYSIS.md](docs/BUNDLE_ANALYSIS.md)
-- Unit Tests: **1497 passing** (125 test files, 123 passed + 2 skipped), E2E: 56 specs
+- Unit Tests: **1810 passing** (166 test files passed + 2 skipped; 4 skipped, 31 todo), E2E: 58 specs — verified 2026-07-14 (`npm test`, vitest 4.1.9)
 - Key Issues: 0 layer-boundary violations, 0/50 `any` budget, **0 файлов >800 LOC в `src/`** (исключая generated types.ts и статический drum-kits.ts) — `supabase/functions/` не входит в этот scope и содержит 11 файлов >800 LOC (до 1871 LOC), не охваченных ни одним sprint'ом, см. [docs/audit/PROGRESS-AUDIT-2026-07-07.md](docs/audit/PROGRESS-AUDIT-2026-07-07.md); tsc 0 errors, rules-of-hooks `"error"`
 - Overall Progress: 99% (49 sprints complete in PROJECT_STATUS; в SPRINT-PROGRESS.md — компактная нумерация до 045)
 
@@ -610,7 +610,7 @@ Logger persists to sessionStorage and integrates with Sentry.
 
 ---
 
-**Last Updated:** 2026-07-09 (Sprint 050 ✅ Complete; tsc 0 errors; 1525 unit tests; Lighthouse CI added; Branch Protection active)
+**Last Updated:** 2026-07-14 (Sprint 065 🔄 in progress — Generate v2 + Home Redesign + Visual Regression; tsc 0 errors; **1810 unit tests passing**; Storybook stories added for `HomeMobileSynthHero` + `BrandEmptyState`. Canonical plan: [WORKPLAN-2026-07-14.md](WORKPLAN-2026-07-14.md))
 
 ## graphify
 

--- a/src/components/common/BrandEmptyState.stories.tsx
+++ b/src/components/common/BrandEmptyState.stories.tsx
@@ -1,0 +1,103 @@
+/**
+ * Storybook stories — BrandEmptyState
+ *
+ * Demonstrates the onboarding-quality, brand-anchored empty state used across
+ * Library / Community / Projects after the Neon Studio redesign (Sprint 065).
+ *
+ * Coverage:
+ * - Minimal (title only)
+ * - Eyebrow + description + hint chips
+ * - Primary + secondary actions
+ * - Custom icon + realistic Library-empty usage
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { Sparkles, Music2, Search, Library, Wand2, Plus } from "@/lib/icons";
+import { BrandEmptyState } from "./BrandEmptyState";
+
+const meta: Meta<typeof BrandEmptyState> = {
+  title: "Common/BrandEmptyState",
+  component: BrandEmptyState,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Brand-anchored empty state (locked Neon Studio palette: violet #7C5CFF + mint #22E4A7, Bricolage Grotesque headings). Supports an eyebrow, description, hint chips, and up to two actions.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    icon: { control: false },
+    eyebrow: { control: "text" },
+    title: { control: "text" },
+    description: { control: "text" },
+    hints: { control: "object" },
+    primaryAction: { control: false },
+    secondaryAction: { control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BrandEmptyState>;
+
+export const Minimal: Story = {
+  args: {
+    title: "Здесь пока пусто",
+  },
+  parameters: {
+    docs: { description: { story: "Bare minimum — just a title with the default Sparkles anchor." } },
+  },
+};
+
+export const WithHints: Story = {
+  args: {
+    icon: Sparkles,
+    eyebrow: "С чего начать",
+    title: "Создай свой первый трек",
+    description: "Опиши идею — стиль, настроение, вокал — и MusicVerse соберёт две версии за минуту.",
+    hints: ["фонк про ночной Токио", "ло-фай для учёбы", "эпичный оркестр"],
+  },
+  parameters: {
+    docs: { description: { story: "Eyebrow, description, and tappable idea chips for onboarding." } },
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    icon: Music2,
+    eyebrow: "Библиотека",
+    title: "Твоя музыка появится здесь",
+    description: "Сгенерируй трек или загрузи собственный — всё сохранится в одном месте.",
+    primaryAction: { label: "Создать трек", onClick: () => {}, icon: Wand2, variant: "primary" },
+    secondaryAction: { label: "Загрузить", onClick: () => {}, icon: Plus, variant: "ghost" },
+  },
+  parameters: {
+    docs: { description: { story: "Primary (mint) + secondary (ghost) actions with icons." } },
+  },
+};
+
+export const LibraryEmpty: Story = {
+  args: {
+    icon: Library,
+    title: "В библиотеке пока нет треков",
+    description: "Начни с генерации — готовые треки будут храниться здесь.",
+    primaryAction: { label: "Сгенерировать", onClick: () => {}, icon: Wand2 },
+  },
+  parameters: {
+    docs: { description: { story: "Realistic Library empty state with a single primary action." } },
+  },
+};
+
+export const SearchNoResults: Story = {
+  args: {
+    icon: Search,
+    eyebrow: "Поиск",
+    title: "Ничего не найдено",
+    description: "Попробуй изменить запрос или сбросить фильтры.",
+    secondaryAction: { label: "Сбросить фильтры", onClick: () => {} },
+  },
+  parameters: {
+    docs: { description: { story: "No-results variant with a single ghost action." } },
+  },
+};

--- a/src/components/common/BrandEmptyState.tsx
+++ b/src/components/common/BrandEmptyState.tsx
@@ -97,7 +97,6 @@ function BrandEmptyStateImpl({
           </p>
         )}
 
-
         {hints && hints.length > 0 && (
           <ul className="mt-3 sm:mt-5 flex flex-wrap justify-center gap-1.5 sm:gap-2" aria-label="Идеи для старта">
             {hints.map((hint) => (
@@ -110,7 +109,6 @@ function BrandEmptyStateImpl({
             ))}
           </ul>
         )}
-
 
         {(primaryAction || secondaryAction) && (
           <div className="mt-4 sm:mt-6 flex flex-col-reverse sm:flex-row items-stretch sm:items-center justify-center gap-2 w-full sm:w-auto">

--- a/src/components/home/HomeMobileSynthHero.stories.tsx
+++ b/src/components/home/HomeMobileSynthHero.stories.tsx
@@ -1,0 +1,72 @@
+/**
+ * Storybook stories — HomeMobileSynthHero
+ *
+ * Cyber-synth mobile home hero from the Neon Studio redesign (Sprint 065):
+ * stat chips (credits + streak), violet-gradient prompt card, and a
+ * "Продолжи создавать" continue-draft strip.
+ *
+ * Auth is provided by the Storybook mock (`.storybook/mocks/AuthContext.tsx`),
+ * which resolves a signed-in user, so the chips and continue-strip render.
+ * `useUserCredits` degrades gracefully to zeros without a live backend.
+ */
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { HomeMobileSynthHero } from "./HomeMobileSynthHero";
+
+const PhoneFrame = ({ children }: { children: ReactNode }) => (
+  <div
+    style={{
+      width: 390,
+      maxWidth: "100%",
+      margin: "0 auto",
+      padding: 16,
+      background: "#0A0B14",
+      borderRadius: 24,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const meta: Meta<typeof HomeMobileSynthHero> = {
+  title: "Home/HomeMobileSynthHero",
+  component: HomeMobileSynthHero,
+  parameters: {
+    layout: "fullscreen",
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        component:
+          "Mobile-only home hero (renders only on mobile in the app). Locked palette: bg #0A0B14, surface #12142B, violet #7C5CFF, mint #22E4A7. Signed-in user comes from the Storybook auth mock.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    onCreateClick: { action: "onCreateClick" },
+  },
+  decorators: [
+    (Story) => (
+      <PhoneFrame>
+        <Story />
+      </PhoneFrame>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof HomeMobileSynthHero>;
+
+export const Default: Story = {
+  args: {
+    onCreateClick: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Full hero for a signed-in user: stat chips, prompt card, and continue-draft strip. Typing a prompt and pressing “Создать” fires onCreateClick with the trimmed text.",
+      },
+    },
+  },
+};

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -278,7 +278,6 @@ export default function Community() {
           </div>
         </motion.header>
 
-
         {/* Search */}
         {/* Active tag indicator */}
         {tagFromUrl && (
@@ -348,15 +347,27 @@ export default function Community() {
         {/* Tabs */}
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
           <TabsList className="grid w-full grid-cols-3 mb-6 h-11">
-            <TabsTrigger value="tracks" aria-label="Треки" className="gap-1.5 text-xs sm:text-sm px-1 min-h-11 touch-manipulation transition-transform active:scale-[0.97]">
+            <TabsTrigger
+              value="tracks"
+              aria-label="Треки"
+              className="gap-1.5 text-xs sm:text-sm px-1 min-h-11 touch-manipulation transition-transform active:scale-[0.97]"
+            >
               <Music className="w-4 h-4 shrink-0" />
               <span className="truncate">Треки</span>
             </TabsTrigger>
-            <TabsTrigger value="popular" aria-label="Популярное" className="gap-1.5 text-xs sm:text-sm px-1 min-h-11 touch-manipulation transition-transform active:scale-[0.97]">
+            <TabsTrigger
+              value="popular"
+              aria-label="Популярное"
+              className="gap-1.5 text-xs sm:text-sm px-1 min-h-11 touch-manipulation transition-transform active:scale-[0.97]"
+            >
               <TrendingUp className="w-4 h-4 shrink-0" />
               <span className="truncate">Топ</span>
             </TabsTrigger>
-            <TabsTrigger value="artists" aria-label="Артисты" className="gap-1.5 text-xs sm:text-sm px-1 min-h-11 touch-manipulation transition-transform active:scale-[0.97]">
+            <TabsTrigger
+              value="artists"
+              aria-label="Артисты"
+              className="gap-1.5 text-xs sm:text-sm px-1 min-h-11 touch-manipulation transition-transform active:scale-[0.97]"
+            >
               <Users className="w-4 h-4 shrink-0" />
               <span className="truncate">Артисты</span>
             </TabsTrigger>


### PR DESCRIPTION
## 📝 Описание

Закрывающие задачи **Sprint 065** (Generate v2 + Home Redesign + Visual Regression): B3 (Storybook-стори для компонентов Neon Studio) и B4 (синхронизация `CLAUDE.md` с реальными, проверяемыми цифрами). **Рантайм-код приложения не менялся** — только Storybook-стори, документация и косметический prettier-проход по двум файлам.

> **Правка от 2026-07-14 (обновление после прогонов CI):** ранее в этом описании фигурировал «блокер `react-is` / `recharts`». Это оказалось **ложной тревогой** — артефактом повреждённого локального `node_modules` в песочнице. `react-is@19.2.7` уже присутствует в `package-lock.json` (peer), поэтому `npm ci --legacy-peer-deps` в CI ставит его детерминированно, и **`vite build` в CI зелёный** (3 build-джоба ✅ + CI-summary «Vite build ✅ pass»). Никаких правок зависимостей не требуется. Реальный предсуществующий красный на `main` — отдельная E2E-проблема (только WebKit), разобрана в разделе «Дополнительные заметки»; к этому диффу отношения не имеет.

**Изменения (файлы):**

- `src/components/home/HomeMobileSynthHero.stories.tsx` — _(новый)_ стори мобильного cyber-synth home hero. Авторизованный пользователь берётся из Storybook-мока `AuthContext`; phone-frame декоратор, viewport `mobile1`, `autodocs`.
- `src/components/common/BrandEmptyState.stories.tsx` — _(новый)_ 5 стори: `Minimal`, `WithHints`, `WithActions`, `LibraryEmpty`, `SearchNoResults`. Покрывают eyebrow, description, hint-чипы и до двух действий.
- `CLAUDE.md` — синхронизация с проверяемыми цифрами (`find`/`wc`/CI, 2026-07-14).
- `.prettierignore` — добавлен авто-генерируемый `supabase/functions/mcp/index.ts` (баннер «do not edit» в файле) рядом с уже игнорируемым sibling'ом, чтобы `format:check` не спотыкался о bundled-вывод.
- `src/pages/Community.tsx`, `src/components/common/BrandEmptyState.tsx` — `prettier --write`, косметика (снятие двойных пустых строк / перенос атрибутов). Семантика/рантайм не изменены.

## 🎯 Тип изменения

- [x] 📚 Documentation (только изменения документации)
- [x] ✅ Tests (добавление или обновление тестов) — Storybook-стори
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] 🎨 Style — косметический prettier-проход
- [ ] 🔧 Chore

## 🔗 Связанные Issues

Отдельного issue нет. Работа ведётся по канонному плану `WORKPLAN-2026-07-14.md`, Sprint 065 (закрытие) → Sprint 066 (backlog).

## 📋 Чеклист перед созданием PR

### 🔍 Код

- [x] Мой код следует стайл-гайду этого проекта (eslint + prettier прогнаны pre-commit хуком)
- [x] Я провёл самопроверку своего кода
- [x] Я прокомментировал сложные участки кода (header-JSDoc в обоих стори-файлах)
- [x] Мои изменения не генерируют новых предупреждений (`tsc` 0 ошибок)
- [x] Я проверил свой код на наличие опечаток

### 📚 Документация

- [x] Я обновил документацию (`CLAUDE.md` синхронизирован с sourced-цифрами)
- [x] Я добавил/обновил комментарии JSDoc (header-doc в стори)
- [ ] Я обновил README.md — не требуется
- [ ] Я обновил CHANGELOG.md — не трогал в этом PR (кандидат на отдельный проход)

### ✅ Тестирование

- [x] Новые и существующие unit-тесты проходят локально — **1810 passing** (vitest 4.1.9; 4 skipped, 31 todo)
- [x] Все существующие тесты всё ещё проходят
- [x] Стори типизируются чисто в изоляции (`tsc`, 0 ошибок)
- [ ] Я проверил изменения в различных браузерах — N/A (нет рантайм-изменений)
- [ ] Я проверил изменения на мобильных устройствах — N/A (стори рассчитаны на `mobile1` viewport в Storybook)

### 🔨 Сборка

- [x] `npm run build` — **зелёный в CI**: `Build & Size Check` ✅ + `Build & Bundle Size` ✅ (×2) + CI-summary «Vite build ✅ pass». (`react-is` уже в lockfile; локальный сбой сборки в песочнице был из-за повреждённого `node_modules`, а не реальной проблемы.)
- [x] `npm run lint` не показывает ошибок (eslint --fix через pre-commit) — CI `Quality Check` / `Lint / TypeCheck / Unit Tests` ✅
- [x] `npm run test` проходит успешно (1810 passing) — CI ✅
- [x] `npm run format` применён к изменённым файлам (prettier через pre-commit); `format:check` по всему репо зелёный после добавления generated-файла в `.prettierignore`

### 🔐 Безопасность

- [x] Мои изменения не вводят уязвимостей безопасности (docs + стори + косметика)
- [x] Я не коммичу секреты, ключи или чувствительные данные (перед коммитом явно проверил, что `package.json`, `package-lock.json`, `supabase/functions/mcp/index.ts` остались нетронуты)
- [ ] `npm audit` — на default-ветке остаются 2 уязвимости (1 moderate, 1 low), появившиеся не в этом PR; разбор — в Sprint 066 (Dependency Health)

## 🧪 Тестирование

### Сценарии тестирования

1. `npm test` → **1810 passed**, 2 skipped test-файла, 4 skipped + 31 todo теста (vitest 4.1.9).
2. Изолированный `tsc` по стори-файлам → **0 ошибок** (стори исключены из `typecheck:app`, поэтому не влияют на app-гейт).
3. Верификация сборки в CI: `Build & Size Check` ✅, `Build & Bundle Size` ✅ (×2). Полный лог `vite build` — в артефакте `vite-build-log` соответствующего run'а.

## 📸 Скриншоты / Записи

N/A — рантайм UI не менялся. Добавленные стори визуализируются в Storybook (`npm run storybook`): `Home/HomeMobileSynthHero` и `Common/BrandEmptyState`.

## 🎨 UI/UX изменения

- **Компоненты затронуты:** `HomeMobileSynthHero`, `BrandEmptyState` — только добавлены стори, сами компоненты не изменялись (кроме снятия двойных пустых строк prettier'ом в `BrandEmptyState.tsx`).
- **Новые паттерны:** нет.
- **Изменения в дизайн-системе:** нет (стори фиксируют locked Neon Studio палитру для визуальной регрессии).

## ⚡ Влияние на производительность

- **Размер bundle:** без изменений (стори не входят в production-бандл, `.md` на бандл не влияет).
- **Время загрузки:** без изменений.
- **Lighthouse score:** без изменений (`Lighthouse CI` ✅ в CI).

## 🔄 Миграция

Требуется ли миграция?

- [x] Нет

## 📝 Дополнительные заметки

### ✅ Итог по CI для этого PR

Все гейты, относящиеся к диффу, **зелёные**: build (×3), lint/typecheck, unit (1810), Smoke **chromium** ✅ / **firefox** ✅, Lighthouse, MkDocs, Markdown, `format:check`.

### ⚠️ Предсуществующий красный на `main` (НЕ вызван этим PR) — WebKit-only dev auto-auth loop

Обнаружено при babysitting CI этого PR. **Красное на `main` держится несколько коммитов подряд** (`8efd953` — база этого PR — и раньше: `1465b46`, `d8f46c6a`, `0db54a62`), то есть предсуществующее и к этому диффу отношения не имеет.

- **Симптом:** падают `Smoke (webkit)`, `Visual Regression (Home)`, `E2E Tests (Mobile emulation)`. Smoke на **chromium и firefox — зелёный**; краснит **только WebKit**.
- **Ошибка (из job-лога webkit):** `uncaught page errors in webkit: Fetch API cannot load https://…supabase.co/auth/v1/token?grant_type=password due to access control checks` — **120** одинаковых uncaught-ошибок; smoke ассертит `pageErrors === []`.
- **Первопричина:** `src/pages/Auth.tsx` (стрк. 49–56) — эффект «auto-authenticate in development mode», который на `/auth` в dev-режиме (в CI Telegram отсутствует → `isDevelopmentMode = true`) авто-вызывает `handleAuth()` → `authenticateWithTelegram()` → `supabase.auth.signInWithPassword` (test-user). После каждой неудачной попытки `isAuthenticating` возвращается в `false`, что **пере-триггерит эффект → бесконечный ретрай**. В chromium/firefox запрос проходит (логин успешен, цикл останавливается); в WebKit запрос блокируется CORS/access-control, каждая попытка всплывает как uncaught error.
- **НЕ влияет на пользователей:** в проде (Telegram Mini App) `isDevelopmentMode = false`, эффект не срабатывает. Это дефект тест-/CI-окружения, а не продовый баг.
- **Варианты фикса (design-решение за owner'ом кода, вне scope этого docs-PR):** (a) one-shot guard (`useRef`) на dev-auto-auth, чтобы не ретраить; (b) не запускать auto-auth под Playwright/CI; (c) выдать E2E валидные Supabase-креды / настроить CORS allowed-origins тестового инстанса; (d) фильтровать известную network-ошибку supabase-auth в smoke-харнессе (там уже фильтруются telegram/analytics 404). Предлагается вынести отдельным маленьким PR.

### Скоуп коммитов

`cc05498` — стори + `CLAUDE.md` (строго 3 файла). `c4a36e8` — `.prettierignore` + 2 косметических prettier-прохода. Перед каждым коммитом провалидировано, что `package.json`, `package-lock.json`, `supabase/functions/mcp/index.ts` не тронуты.

### Проверяемая база (2026-07-14)

`tsc` 0 ошибок; **1810** unit-тестов passing; стори типизируются чисто; build зелёный в CI. Цифры в `CLAUDE.md` получены через `find`/`wc`/CI.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)