### PR TITLE
feat(player): loading-arc pulse ring on play affordance (P5)

### DIFF
--- a/src/components/player/CompactPlayerButtons.tsx
+++ b/src/components/player/CompactPlayerButtons.tsx
@@ -53,41 +53,49 @@ export const PlayBtn = memo(function PlayBtn({
   const { t } = useTranslation();
   const iconSize = variant === "desktop" ? "h-6 w-6" : "h-5 w-5";
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={onClick}
-      disabled={isLoading}
-      className={cn(
-        "rounded-full bg-primary/10 hover:bg-primary/20 hover:scale-105 active:scale-95 transition-all motion-reduce:transition-none motion-reduce:active:scale-100 motion-reduce:hover:scale-100",
-        variant === "desktop" ? "h-12 w-12" : "h-11 w-11",
-        TOUCH,
-        hasError && "bg-destructive/15 hover:bg-destructive/25",
+    <span className="relative inline-flex items-center justify-center">
+      {isLoading && !hasError && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -m-1.5 rounded-full border-2 border-primary/50 pulse-ring motion-reduce:hidden"
+        />
       )}
-      aria-label={
-        hasError
-          ? t("player.buttons.errorLabel")
-          : isLoading
-            ? t("player.buttons.loadingLabel")
-            : isPlaying
-              ? t("player.buttons.pauseLabel")
-              : t("player.buttons.playLabel")
-      }
-      aria-busy={isLoading}
-      aria-pressed={isPlaying}
-      title={hasError ? playbackError || t("player.compact.errorFallback") : undefined}
-      data-testid="compact-player-play"
-    >
-      {hasError ? (
-        <AlertCircle className={cn("text-destructive", iconSize)} aria-hidden="true" />
-      ) : isLoading ? (
-        <Loader2 className={cn("animate-spin motion-reduce:animate-none", iconSize)} aria-hidden="true" />
-      ) : isPlaying ? (
-        <Pause className={iconSize} fill="currentColor" aria-hidden="true" />
-      ) : (
-        <Play className={cn("ml-0.5", iconSize)} fill="currentColor" aria-hidden="true" />
-      )}
-    </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onClick}
+        disabled={isLoading}
+        className={cn(
+          "relative rounded-full bg-primary/10 hover:bg-primary/20 hover:scale-105 active:scale-95 transition-all motion-reduce:transition-none motion-reduce:active:scale-100 motion-reduce:hover:scale-100",
+          variant === "desktop" ? "h-12 w-12" : "h-11 w-11",
+          TOUCH,
+          hasError && "bg-destructive/15 hover:bg-destructive/25",
+        )}
+        aria-label={
+          hasError
+            ? t("player.buttons.errorLabel")
+            : isLoading
+              ? t("player.buttons.loadingLabel")
+              : isPlaying
+                ? t("player.buttons.pauseLabel")
+                : t("player.buttons.playLabel")
+        }
+        aria-busy={isLoading}
+        aria-pressed={isPlaying}
+        title={hasError ? playbackError || t("player.compact.errorFallback") : undefined}
+        data-testid="compact-player-play"
+      >
+        {hasError ? (
+          <AlertCircle className={cn("text-destructive", iconSize)} aria-hidden="true" />
+        ) : isLoading ? (
+          <Loader2 className={cn("animate-spin motion-reduce:animate-none", iconSize)} aria-hidden="true" />
+        ) : isPlaying ? (
+          <Pause className={iconSize} fill="currentColor" aria-hidden="true" />
+        ) : (
+          <Play className={cn("ml-0.5", iconSize)} fill="currentColor" aria-hidden="true" />
+        )}
+      </Button>
+    </span>
   );
 });
 


### PR DESCRIPTION
## Summary

Phase 5 of mobile redesign (Suno-informed loading-arc on play affordance).

### Problem
When the user taps play on the CompactPlayer, the only load feedback is a spinning `Loader2` inside the button. No ambient "loading arc" — the affordance reads as static during buffer.

### Fix (`CompactPlayerButtons.tsx`)
- Wrap `PlayBtn`'s `<Button>` in a `relative inline-flex` span.
- When `isLoading && !hasError`, render an absolutely-positioned `border-primary/50 pulse-ring` overlay around the button (reuses the existing `.pulse-ring` CSS class + keyframes already used by `CreateArtistDialog`).
- `isLoading` (CompactPlayer L54) already covers `playbackStatus === "loading" || "buffering"`, so the ring fires on both initial load and mid-stream buffer.
- Overlay is `aria-hidden`, `pointer-events-none`, `motion-reduce:hidden`.

### Not in this PR
- Per-card `PlayOverlay` ring on covers — deferred; the persistent CompactPlayer is the canonical play surface and the highest-value single point.
- `animate-pulse-ring` Tailwind utility — used the existing `.pulse-ring` CSS class instead (already on disk, no config change).

## Test plan
- [x] `npm run build` clean (tsc 0)
- [x] `npm test` — 1810 passing (baseline held)
- [x] `npm run size` — PASS
- [ ] Manual: tap a track, confirm pulse ring appears around play button during buffer, disappears on playback start

🤖 Generated with [Claude Code](https://claude.com/claude-code)
