### PR TITLE
fix(pages): repair github pages homepage 404 and stop failing jekyll builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -114,5 +114,17 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Assert the "GitHub Actions" Pages build type. The repo also has a legacy
+      # "Deploy from a branch" source active, which triggers the Jekyll-based
+      # pages-build-deployment on every push to main; that builder renders the
+      # whole markdown tree and fails on Liquid ({{ }}) syntax. Enabling the
+      # workflow build type makes this MkDocs deployment the single source of
+      # truth. continue-on-error so a config-API hiccup never blocks the deploy.
+      - name: Configure Pages (assert GitHub Actions source)
+        continue-on-error: true
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: MusicVerse AI Docs
 site_description: Documentation for the MusicVerse AI Telegram Mini App
-site_url: https://aimusicverse.github.io/docs/
-repo_url: https://github.com/aimusicverse/musicverse
+site_url: https://how2ai-agency.github.io/aimusicverse/
+repo_url: https://github.com/how2ai-agency/aimusicverse
 edit_uri: edit/main/
 docs_dir: .
 site_dir: site
@@ -92,6 +92,10 @@ nav:
       - Navigation: docs/NAVIGATION.md
 
 exclude_docs: |
+  # Vite SPA entry at the repo root. Its output path (index.html) collides with
+  # README.md -> index.html, which makes MkDocs drop the homepage (root 404).
+  # Excluding it lets README.md become the site homepage.
+  /index.html
   node_modules/
   dist/
   build/


### PR DESCRIPTION
## 📝 Описание

Исправляет проблему с публикацией **GitHub Pages**: корень сайта документации возвращал **404**, а каждый push в `main` запускал падающую легаси-сборку `pages-build-deployment` (Jekyll).

**Причины:**

1. **Домашняя страница (404).** `docs_dir` — корень репозитория, поэтому `README.md` отображается в `index.html` — тот же выходной путь, что и у точки входа Vite (`index.html`). MkDocs отбрасывал конфликтующую домашнюю страницу, поэтому корень сайта отдавал 404, хотя вложенные страницы работали.
2. **Неверные `site_url` / `repo_url`.** Указывали на несуществующие хост и репозиторий, из-за чего в `404.html`, `sitemap.xml` и ссылки «редактировать» зашивался устаревший префикс `/docs/`.
3. **Падающая легаси-сборка Jekyll.** У репозитория активен источник Pages «Deploy from a branch», который на каждый push собирает всё markdown-дерево через Jekyll и падает на синтаксисе Liquid (`{{ }}`).

**Что сделано:**

- Исключён корневой Vite `index.html` из сборки документации → `README.md` становится домашней страницей (корневой `index.html` теперь генерируется).
- Исправлены `site_url` → `https://how2ai-agency.github.io/aimusicverse/` и `repo_url` → реальный репозиторий.
- В workflow деплоя добавлен `actions/configure-pages@v5` (`enablement: true`), утверждающий тип сборки «GitHub Actions», чтобы MkDocs-деплой стал единственным источником истины вместо падающей ветковой Jekyll-сборки.

**Проверено** полной локальной сборкой `mkdocs build`: корневой `index.html` рендерит README, `sitemap.xml` / `404.html` используют базу `/aimusicverse/`, префикс `/docs/` полностью исчез.

## 🎯 Тип изменения

- [x] 🐛 Bug fix (исправление ошибки)
- [x] 🔧 Chore (обновление конфигураций)

## 🔗 Связанные Issues

Отдельного issue нет — правка по обращению о проблеме публикации GitHub Pages.

## 📋 Чеклист перед созданием PR

### 🔍 Код

- [x] Код следует стайл-гайду проекта
- [x] Проведена самопроверка кода
- [x] Сложные участки прокомментированы (пояснения прямо в `mkdocs.yml` и `docs.yml`)
- [x] Изменения не генерируют новых предупреждений сборки
- [x] Проверено на опечатки

### 📚 Документация

- [x] Обновлена конфигурация сборки docs-сайта
- [ ] JSDoc — неприменимо
- [ ] README.md — без изменений (теперь корректно рендерится как homepage)
- [ ] CHANGELOG.md — не требуется для инфраструктурной правки Pages

### ✅ Тестирование

- [x] Полная локальная сборка `mkdocs build` (exit 0)
- [x] Корневой `index.html` генерируется и рендерит README
- [x] `sitemap.xml` / `404.html` используют базу `/aimusicverse/`; вхождений `/docs/` не осталось (0)
- [ ] Кроссбраузерность / мобильные — неприменимо (правка конфигурации Pages)

### 🔨 Сборка

- [x] Docs workflow (`mkdocs build`) выполняется успешно
- [ ] `npm run lint` / `test` / `format` — не затрагиваются (нет изменений в `src/`)

### 🔐 Безопасность

- [x] Изменения не вводят уязвимостей безопасности
- [x] Секреты/ключи не коммитятся

## 🧪 Тестирование

### Сценарии тестирования

1. Полная локальная сборка `mkdocs build` с реальным `mkdocs.yml` (все плагины) → exit 0, сгенерирован корневой `index.html` (README как homepage).
2. Проверка выходных путей: `sitemap.xml` и `404.html` используют базу `/aimusicverse/`; вхождений `/docs/` — 0.
3. Диагностика «живого» сайта: корень `https://how2ai-agency.github.io/aimusicverse/` → 404; вложенная страница `/DOCUMENTATION_INDEX/` → 200 (подтверждает причину).

## ⚡ Влияние на производительность

- **Размер bundle:** без изменений (правка не затрагивает приложение)

## 🔄 Миграция

Требуется ли миграция?

- [ ] Да
- [x] Нет

## 📝 Дополнительные заметки

⚠️ **Требуется одно ручное действие в настройках репозитория для полного устранения падающих Jekyll-сборок:**

**Settings → Pages → Build and deployment → Source → «GitHub Actions».**

Сейчас источник — «Deploy from a branch», что и запускает падающий `pages-build-deployment` (Jekyll) на каждый push. Шаг `configure-pages@v5` в этом PR пытается переключить это автоматически (токеном workflow с правами `pages: write`); если ограничения организации это заблокируют, переключение в настройках делается в один клик. Исправление домашней страницы (404 → homepage) работает независимо от этого и вступит в силу при мердже в `main`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pg5ngQZ6eNDPP8xdxopV3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg5ngQZ6eNDPP8xdxopV3c)_